### PR TITLE
Feat/#32/contents

### DIFF
--- a/prisma/migrations/20250904070716_add_content_table/migration.sql
+++ b/prisma/migrations/20250904070716_add_content_table/migration.sql
@@ -1,0 +1,43 @@
+-- CreateEnum
+CREATE TYPE "ContentStatus" AS ENUM ('WRITING', 'PUBLISHED', 'HIDDEN');
+
+-- CreateTable
+CREATE TABLE "contents" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "image_url" TEXT,
+    "status" "ContentStatus" NOT NULL DEFAULT 'WRITING',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    "subCategoryId" INTEGER NOT NULL,
+
+    CONSTRAINT "contents_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "content_main_categories" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "content_main_categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "content_sub_categories" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "mainCategoryId" INTEGER NOT NULL,
+
+    CONSTRAINT "content_sub_categories_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "contents" ADD CONSTRAINT "contents_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contents" ADD CONSTRAINT "contents_subCategoryId_fkey" FOREIGN KEY ("subCategoryId") REFERENCES "content_sub_categories"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "content_sub_categories" ADD CONSTRAINT "content_sub_categories_mainCategoryId_fkey" FOREIGN KEY ("mainCategoryId") REFERENCES "content_main_categories"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250911114419_add_content_image_table/migration.sql
+++ b/prisma/migrations/20250911114419_add_content_image_table/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `image_url` on the `contents` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "contents" DROP COLUMN "image_url";
+
+-- CreateTable
+CREATE TABLE "content_images" (
+    "id" SERIAL NOT NULL,
+    "content_id" INTEGER NOT NULL,
+    "url" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "content_images_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "content_images" ADD CONSTRAINT "content_images_content_id_fkey" FOREIGN KEY ("content_id") REFERENCES "contents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250915075831_scrap_and_content_view/migration.sql
+++ b/prisma/migrations/20250915075831_scrap_and_content_view/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "scraps" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "contentId" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "scraps_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "content_views" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "contentId" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "content_views_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "scraps_userId_contentId_key" ON "scraps"("userId", "contentId");
+
+-- AddForeignKey
+ALTER TABLE "scraps" ADD CONSTRAINT "scraps_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "scraps" ADD CONSTRAINT "scraps_contentId_fkey" FOREIGN KEY ("contentId") REFERENCES "contents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "content_views" ADD CONSTRAINT "content_views_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "content_views" ADD CONSTRAINT "content_views_contentId_fkey" FOREIGN KEY ("contentId") REFERENCES "contents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model User {
   sentLetters     Letter[]   @relation("SentLetters")
   receivedLetters Letter[]   @relation("ReceivedLetters")
   schedule        Schedule[]
+  contents       Content[]
 
   @@map("users")
 }
@@ -88,4 +89,46 @@ model Gift {
   imageUrl String       @map("image_url")
 
   @@map("gifts")
+}
+
+model Content {
+  id Int @id @default(autoincrement())
+  title String
+  body String
+  imageUrl String? @map("image_url")
+  status ContentStatus @default(WRITING)
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // Relations
+  authorId Int
+  author User @relation(fields: [authorId], references: [id])
+  subCategoryId Int
+  subCategory ContentSubCategory @relation(fields: [subCategoryId], references:[id])
+
+  @@map("contents")
+
+}
+
+model ContentMainCategory {
+  id Int @id @default(autoincrement())
+  name String
+  subs ContentSubCategory[]
+
+  @@map("content_main_categories")
+}
+
+model ContentSubCategory {
+  id Int @id @default(autoincrement())
+  name String
+  mainCategoryId Int
+  mainCategory ContentMainCategory @relation(fields: [mainCategoryId], references: [id])
+  contents Content[]
+  @@map("content_sub_categories")
+}
+
+enum ContentStatus {
+  WRITING
+  PUBLISHED
+  HIDDEN
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,7 +95,6 @@ model Content {
   id Int @id @default(autoincrement())
   title String
   body String
-  imageUrl String? @map("image_url")
   status ContentStatus @default(WRITING)
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
@@ -105,9 +104,20 @@ model Content {
   author User @relation(fields: [authorId], references: [id])
   subCategoryId Int
   subCategory ContentSubCategory @relation(fields: [subCategoryId], references:[id])
+  images ContentImage[]
 
   @@map("contents")
 
+}
+
+model ContentImage {
+  id Int @id @default(autoincrement())
+  contentId Int @map("content_id")
+  url String @map("url")
+  content Content @relation(fields:[contentId], references:[id])
+  createdAt DateTime @default(now()) @map("created_at")
+  
+  @@map("content_images")
 }
 
 model ContentMainCategory {
@@ -124,6 +134,7 @@ model ContentSubCategory {
   mainCategoryId Int
   mainCategory ContentMainCategory @relation(fields: [mainCategoryId], references: [id])
   contents Content[]
+
   @@map("content_sub_categories")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,8 @@ model User {
   receivedLetters Letter[]   @relation("ReceivedLetters")
   schedule        Schedule[]
   contents       Content[]
+  scraps         Scrap[]
+  contentViews   ContentView[]
 
   @@map("users")
 }
@@ -105,6 +107,8 @@ model Content {
   subCategoryId Int
   subCategory ContentSubCategory @relation(fields: [subCategoryId], references:[id])
   images ContentImage[]
+  scraps Scrap[]
+  views ContentView[]
 
   @@map("contents")
 
@@ -142,4 +146,30 @@ enum ContentStatus {
   WRITING
   PUBLISHED
   HIDDEN
+}
+
+model Scrap {
+  id Int @id @default(autoincrement())
+  userId Int
+  contentId Int
+  createdAt DateTime @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id])
+  content Content @relation(fields: [contentId], references: [id])
+  
+  @@unique([userId, contentId])
+  @@map("scraps")
+
+}
+
+model ContentView {
+  id Int @id @default(autoincrement())
+  userId Int
+  contentId Int
+  createdAt DateTime @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id])
+  content Content @relation(fields: [contentId], references: [id])
+
+  @@map("content_views")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { S3Module } from './s3/s3.module';
 import { ScheduleModule } from './schedule/schedule.module';
 import { GiftModule } from './gift/gift.module';
 import { AdminModule } from './admin/admin.module';
+import { ContentModule } from './contents/content.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { AdminModule } from './admin/admin.module';
     ScheduleModule,
     GiftModule,
     AdminModule,
+    ContentModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/contents/content.controller.ts
+++ b/src/contents/content.controller.ts
@@ -3,8 +3,8 @@ import { ContentService } from './content.service';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiContent } from './content.swagger';
 
-@ApiTags('content')
-@Controller('content')
+@ApiTags('contents')
+@Controller('contents')
 export class ContentController {
   constructor(private readonly contentService: ContentService) {}
 

--- a/src/contents/content.controller.ts
+++ b/src/contents/content.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { ContentService } from './content.service';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiContent } from './content.swagger';
+import { ContentsQueryDto } from './dtos/contents-query.dto';
 
 @ApiTags('contents')
 @Controller('contents')
@@ -11,8 +12,8 @@ export class ContentController {
   /** 콘텐츠 리스트 조회 (카테고리별 필터링) */
   @Get()
   @ApiContent.findAll()
-  async findAll() {
-    return this.contentService.findAllPublishedContents();
+  async findAll(@Query() query: ContentsQueryDto) {
+    return this.contentService.findAllPublishedContents(query);
   }
 
   /** 특정 콘텐츠 상세 조회 */

--- a/src/contents/content.controller.ts
+++ b/src/contents/content.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { ContentService } from './content.service';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiContent } from './content.swagger';
@@ -8,7 +8,7 @@ import { ApiContent } from './content.swagger';
 export class ContentController {
   constructor(private readonly contentService: ContentService) {}
 
-  /** 전체 콘텐츠 리스트 조회 */
+  /** 콘텐츠 리스트 조회 (카테고리별 필터링) */
   @Get()
   @ApiContent.findAll()
   async findAll() {

--- a/src/contents/content.controller.ts
+++ b/src/contents/content.controller.ts
@@ -1,8 +1,20 @@
-import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Param,
+  ParseIntPipe,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { ContentService } from './content.service';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiContent } from './content.swagger';
 import { ContentsQueryDto } from './dtos/contents-query.dto';
+import { FirebaseAuthGuard } from 'src/auth/firebase-auth.guard';
+import { AdminGuard } from 'src/admin/admin.guard';
 
 @ApiTags('contents')
 @Controller('contents')

--- a/src/contents/content.controller.ts
+++ b/src/contents/content.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { ContentService } from './content.service';
+import { ApiTags } from '@nestjs/swagger';
+import { ApiContent } from './content.swagger';
+
+@ApiTags('content')
+@Controller('content')
+export class ContentController {
+  constructor(private readonly contentService: ContentService) {}
+
+  /** 전체 콘텐츠 리스트 조회 */
+  @Get()
+  @ApiContent.findAll()
+  async findAll() {
+    return this.contentService.findAllPublishedContents();
+  }
+
+  /** 특정 콘텐츠 상세 조회 */
+  @Get(':contentId')
+  @ApiContent.findOne()
+  async findOne(@Param('contentId', ParseIntPipe) contentId: number) {
+    return this.contentService.findOnePublishedContent(contentId);
+  }
+}

--- a/src/contents/content.module.ts
+++ b/src/contents/content.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ContentController } from './content.controller';
+import { ContentService } from './content.service';
+import { ContentRepository } from './content.repository';
+
+@Module({
+  controllers: [ContentController],
+  providers: [ContentService, ContentRepository],
+  exports: [ContentService, ContentRepository],
+})
+export class ContentModule {}

--- a/src/contents/content.repository.ts
+++ b/src/contents/content.repository.ts
@@ -1,0 +1,59 @@
+// src/contents/contents.repository.ts
+
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { Content, ContentStatus } from '@prisma/client';
+
+@Injectable()
+export class ContentRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** 전체 공개 콘텐츠 리스트 조회 */
+  async findAllPublished(): Promise<Content[]> {
+    return this.prisma.content.findMany({
+      where: {
+        status: ContentStatus.PUBLISHED,
+      },
+      include: {
+        subCategory: {
+          include: {
+            mainCategory: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+  }
+
+  /** 특정 공개 콘텐츠 상세 조회 */
+  async findOnePublished(contentId: number): Promise<Content | null> {
+    return this.prisma.content.findUnique({
+      where: {
+        id: contentId,
+        status: ContentStatus.PUBLISHED,
+      },
+      include: {
+        author: {
+          select: {
+            id: true,
+            nickname: true,
+          },
+        },
+        subCategory: {
+          select: {
+            id: true,
+            name: true,
+            mainCategory: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+}

--- a/src/contents/content.repository.ts
+++ b/src/contents/content.repository.ts
@@ -9,7 +9,50 @@ export class ContentRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   /** 전체 공개 콘텐츠 리스트 조회 */
-  async findAllPublished(): Promise<Content[]> {
+  async findAllPublished(
+    mainCategoryId?: string,
+    subCategoryId?: string,
+  ): Promise<Content[]> {
+    if (subCategoryId) {
+      return this.prisma.content.findMany({
+        where: {
+          status: ContentStatus.PUBLISHED,
+          subCategoryId: +subCategoryId,
+        },
+        include: {
+          subCategory: {
+            include: {
+              mainCategory: true,
+            },
+          },
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+    }
+
+    if (mainCategoryId) {
+      return this.prisma.content.findMany({
+        where: {
+          status: ContentStatus.PUBLISHED,
+          subCategory: {
+            mainCategoryId: +mainCategoryId,
+          },
+        },
+        include: {
+          subCategory: {
+            include: {
+              mainCategory: true,
+            },
+          },
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+    }
+
     return this.prisma.content.findMany({
       where: {
         status: ContentStatus.PUBLISHED,
@@ -25,6 +68,16 @@ export class ContentRepository {
         createdAt: 'desc',
       },
     });
+  }
+
+  /** 메인 카테고리 존재 여부 확인 */
+  async existMainCategory(id: number): Promise<boolean> {
+    return (await this.prisma.contentMainCategory.count({ where: { id } })) > 0;
+  }
+
+  /** 서브 카테고리 존재 여부 확인 */
+  async existSubCategory(id: number): Promise<boolean> {
+    return (await this.prisma.contentSubCategory.count({ where: { id } })) > 0;
   }
 
   /** 특정 공개 콘텐츠 상세 조회 */

--- a/src/contents/content.service.ts
+++ b/src/contents/content.service.ts
@@ -1,12 +1,37 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { ContentRepository } from './content.repository';
+import { ContentsQueryDto } from './dtos/contents-query.dto';
 
 @Injectable()
 export class ContentService {
   constructor(private readonly contentRepository: ContentRepository) {}
 
-  /** 전체 공개된 콘텐츠 리스트 조회 */
-  async findAllPublishedContents() {
+  /** 공개된 콘텐츠 리스트 조회 (카테고리 필터링) */
+  async findAllPublishedContents(query: ContentsQueryDto) {
+    const { mainCategoryId, subCategoryId } = query;
+
+    if (
+      mainCategoryId &&
+      !(await this.contentRepository.existMainCategory(+mainCategoryId))
+    ) {
+      throw new NotFoundException(
+        `존재하지 않는 메인 카테고리입니다: ${mainCategoryId}`,
+      );
+    }
+
+    if (
+      subCategoryId &&
+      !(await this.contentRepository.existSubCategory(+subCategoryId))
+    ) {
+      throw new NotFoundException(
+        `존재하지 않는 서브 카테고리입니다: ${subCategoryId}`,
+      );
+    }
+
+    return this.contentRepository.findAllPublished(
+      mainCategoryId,
+      subCategoryId,
+    );
     return this.contentRepository.findAllPublished();
   }
 

--- a/src/contents/content.service.ts
+++ b/src/contents/content.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ContentRepository } from './content.repository';
+
+@Injectable()
+export class ContentService {
+  constructor(private readonly contentRepository: ContentRepository) {}
+
+  /** 전체 공개된 콘텐츠 리스트 조회 */
+  async findAllPublishedContents() {
+    return this.contentRepository.findAllPublished();
+  }
+
+  /** 특정 공개된 콘텐츠 상세 조회 */
+  async findOnePublishedContent(contentId: number) {
+    const content = await this.contentRepository.findOnePublished(contentId);
+
+    if (!content) {
+      throw new NotFoundException('게시된 콘텐츠를 찾을 수 없습니다.');
+    }
+    return content;
+  }
+}

--- a/src/contents/content.swagger.ts
+++ b/src/contents/content.swagger.ts
@@ -1,0 +1,74 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Content } from '@prisma/client';
+
+export const ApiContent = {
+  findAll: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '전체 콘텐츠 리스트 조회',
+        description:
+          '모든 사용자에게 공개된 콘텐츠 목록을 최신순으로 조회합니다.',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '공개된 콘텐츠 목록 조회 성공',
+        schema: {
+          example: [
+            {
+              id: 1,
+              title: '첫 번째 콘텐츠 제목',
+              imageUrl: 'https://example.com/image.jpg',
+              createdAt: '2025-07-01T12:00:00Z',
+              subCategory: {
+                id: 1,
+                name: '영화/드라마',
+                mainCategory: {
+                  id: 1,
+                  name: '콘텐츠 추천',
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ),
+  findOne: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '특정 콘텐츠 상세 조회',
+        description: '특정 ID를 가진 공개된 콘텐츠의 상세 정보를 조회합니다.',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '콘텐츠 상세 조회 성공',
+        schema: {
+          example: {
+            id: 1,
+            title: '첫 번째 콘텐츠 제목',
+            body: '콘텐츠 본문 내용입니다.',
+            imageUrl: 'https://example.com/image.jpg',
+            status: 'PUBLISHED',
+            createdAt: '2025-07-01T12:00:00Z',
+            updatedAt: '2025-07-01T12:00:00Z',
+            author: {
+              id: 1,
+              nickname: '관리자닉네임',
+            },
+            subCategory: {
+              id: 5,
+              name: '티켓팅/예약',
+              mainCategory: {
+                id: 1,
+                name: '행사 알림',
+              },
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: '게시된 콘텐츠를 찾을 수 없음',
+      }),
+    ),
+};

--- a/src/contents/content.swagger.ts
+++ b/src/contents/content.swagger.ts
@@ -59,7 +59,7 @@ export const ApiContent = {
               id: 5,
               name: '티켓팅/예약',
               mainCategory: {
-                id: 1,
+                id: 2,
                 name: '행사 알림',
               },
             },

--- a/src/contents/dtos/content-image-upload.dto.ts
+++ b/src/contents/dtos/content-image-upload.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class ContentImageUploadDto {
+  @ApiProperty({ example: 'image_1.jpg', description: '원래 파일 이름' })
+  @IsString()
+  @IsNotEmpty()
+  filename: string;
+
+  @ApiProperty({ example: 'image/jpeg', description: '파일 MIME 타입' })
+  @IsString()
+  @IsNotEmpty()
+  contentType: string;
+}

--- a/src/contents/dtos/contents-query.dto.ts
+++ b/src/contents/dtos/contents-query.dto.ts
@@ -1,20 +1,20 @@
-import { IsOptional, IsNumberString} from 'class-validator';
+import { IsOptional, IsNumberString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class ContentsQueryDto {
-    @ApiProperty({
-        description: '메인 카테고리 ID',
-        required: false,
-    }),
-    @IsOptional()
-    @IsNumberString()
-    mainCategoryId?: string;
+  @ApiProperty({
+    description: '메인 카테고리 ID',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumberString()
+  mainCategoryId?: string;
 
-    @ApiProperty({
-        description: '서브 카테고리 ID',
-        required: false,
-    })
-    @IsOptional()
-    @IsNumberString()
-    subCategoryId?: string;
+  @ApiProperty({
+    description: '서브 카테고리 ID',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumberString()
+  subCategoryId?: string;
 }

--- a/src/contents/dtos/contents-query.dto.ts
+++ b/src/contents/dtos/contents-query.dto.ts
@@ -1,0 +1,20 @@
+import { IsOptional, IsNumberString} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ContentsQueryDto {
+    @ApiProperty({
+        description: '메인 카테고리 ID',
+        required: false,
+    }),
+    @IsOptional()
+    @IsNumberString()
+    mainCategoryId?: string;
+
+    @ApiProperty({
+        description: '서브 카테고리 ID',
+        required: false,
+    })
+    @IsOptional()
+    @IsNumberString()
+    subCategoryId?: string;
+}

--- a/src/contents/dtos/create-content.dto.ts
+++ b/src/contents/dtos/create-content.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  Length,
+  IsInt,
+  IsArray,
+  ArrayMinSize,
+  ArrayMaxSize,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ContentImageUploadDto } from './content-image-upload.dto';
+
+export class CreateContentDto {
+  @ApiProperty({ example: 1, description: '콘텐츠를 등록하는 관리자의 ID' })
+  @IsInt()
+  authorId: number;
+
+  @ApiProperty({
+    example: 1,
+    description: '콘텐츠가 속할 서브 카테고리 ID',
+  })
+  @IsInt()
+  subCategoryId: number;
+
+  @ApiProperty({ example: '새로운 콘텐츠 제목', description: '콘텐츠 제목' })
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 100)
+  title: string;
+
+  @ApiProperty({
+    example: '여기에 콘텐츠 본문 내용을 작성합니다.',
+    description: '콘텐츠 본문',
+  })
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+
+  @ApiProperty({
+    type: [ContentImageUploadDto],
+    description: '업로드할 이미지 파일 정보 (1장 이상, 10장 이하)',
+  })
+  @IsArray()
+  @ArrayMinSize(1, { message: '이미지는 최소 1장 이상 업로드해야 합니다.' })
+  @ArrayMaxSize(10, {
+    message: '이미지는 최대 10장까지만 업로드 가능합니다.',
+  })
+  @ValidateNested({ each: true })
+  @Type(() => ContentImageUploadDto)
+  images: ContentImageUploadDto[];
+}

--- a/src/s3/constants/s3.constant.ts
+++ b/src/s3/constants/s3.constant.ts
@@ -1,4 +1,5 @@
 export const S3Folder = {
   LETTERS: 'letters',
   GIFTS: 'gifts',
+  CONTENTS: 'contents',
 } as const;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #32

## 📝작업 내용

> 모든 사용자/클라이언트가 접근 가능한 공개 API인 콘텐츠 조회 기능을 개발했습니다.

1) GET /contents: 전체 콘텐츠 리스트를 조회하는 API를 구현했습니다.
- PUBLISHED 상태의 콘텐츠만 최신순으로 반환합니다.

2) GET /contents/{contentId}: 특정 콘텐츠의 상세 정보를 조회하는 API를 구현했습니다.
- 해당 ID의 콘텐츠가 PUBLISHED 상태인 경우에만 상세 정보를 반환합니다.

3) Postman으로 API 테스트를 완료했습니다.
- GET /contents: 정상적으로 공개된 콘텐츠 목록을 반환하는 것을 확인했습니다.
- GET /contents/1: 1번 콘텐츠의 상세 정보가 정상적으로 반환되는 것을 확인했습니다. / Published 가 아닌 writing 의 경우에는 반환되지 않는 것도 확인했습니다.
- 존재하지 않는 contentId에 대해 404 Not Found 에러가 발생하는 것을 확인했습니다.

### 스크린샷 (선택)
swagger
<img width="789" height="653" alt="image" src="https://github.com/user-attachments/assets/2033199d-421a-4749-8678-db1da82b3a1d" />

<img width="789" height="820" alt="image" src="https://github.com/user-attachments/assets/298808f1-27c0-4b11-a52d-c756573ccc5c" />


## 💬리뷰 요구사항(선택)

> 코드 컨벤션: 파일 및 함수 이름, 변수 명명법 등이 프로젝트 컨벤션에 맞는지 확인해 주세요. (폴더명의 경우 contents, 파일명의 경우 content.controller.ts 등 복수와 단수를 사용했습니다. )
> schema 파일 확인 부탁드립니다. Content Model 괜찮은지 검토 부탁드려요!
