### PR TITLE
music 테이블, CRUD 생성 및 alarm 로직 수정

### DIFF
--- a/prisma/migrations/20250916070909_create_music_table/migration.sql
+++ b/prisma/migrations/20250916070909_create_music_table/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - Added the required column `music_id` to the `alarms` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "alarms" ADD COLUMN     "music_id" INTEGER NOT NULL;
+
+-- CreateTable
+CREATE TABLE "musics" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "artist" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "musics_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "alarms" ADD CONSTRAINT "alarms_music_id_fkey" FOREIGN KEY ("music_id") REFERENCES "musics"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -116,13 +116,25 @@ model DeviceToken {
 model Alarm {
   id          Int      @id @default(autoincrement())
   userId      Int      @unique @map("user_id")
-  scheduledAt DateTime @map("scheduled_at") // 알림 설정 시간(UTC 또는 KST 는 추후 정하고 주석 변경)
+  scheduledAt DateTime @map("scheduled_at") // 알림 설정 시간(KST 기준 설정)
   isFired     Boolean  @default(false) @map("is_fired") // 울렸는지 상태 체크
+  musicId     Int      @map("music_id")
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  music Music @relation(fields: [musicId], references: [id]) // 여기는 Cascade를 일부러 안달았음. -> 음악을 지울때 주의 !
 
   @@index([isFired, scheduledAt])
   @@map("alarms")
+}
+
+model Music {
+  id        Int      @id @default(autoincrement())
+  title     String
+  artist    String
+  createdAt DateTime @default(now()) @map("created_at")
+  alarms    Alarm[]
+
+  @@map("musics")
 }

--- a/src/alarm/alarm.controller.ts
+++ b/src/alarm/alarm.controller.ts
@@ -7,6 +7,7 @@ import {
   Delete,
   Req,
   UseGuards,
+  HttpCode,
 } from '@nestjs/common';
 import { AlarmService } from './alarm.service';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
@@ -42,8 +43,9 @@ export class AlarmController {
   }
 
   @Delete('me')
+  @HttpCode(204)
   @ApiAlarm.delete()
   async remove(@Req() req) {
-    return await this.alarmService.delete(req.user.id);
+    await this.alarmService.delete(req.user.id);
   }
 }

--- a/src/alarm/alarm.repository.ts
+++ b/src/alarm/alarm.repository.ts
@@ -12,13 +12,17 @@ export class AlarmRepository {
       data: {
         userId,
         scheduledAt: new Date(dto.scheduledAt),
+        musicId: dto.musicId,
       },
     });
   }
 
   // 나의 userId 로 알람 조회  ( 여기의 userId 도 Unique로 바꿔야 하는지 )
   findOne(userId: number) {
-    return this.prisma.alarm.findFirst({ where: { userId } });
+    return this.prisma.alarm.findFirst({
+      where: { userId },
+      include: { music: true },
+    });
   }
 
   update(userId: number, dto: UpdateAlarmDto) {
@@ -29,7 +33,9 @@ export class AlarmRepository {
         ...(dto.scheduledAt && {
           scheduledAt: new Date(dto.scheduledAt),
         }),
+        ...(dto.musicId && { musicId: dto.musicId }),
       },
+      include: { music: true },
     });
   }
 
@@ -37,29 +43,27 @@ export class AlarmRepository {
     return this.prisma.alarm.delete({ where: { userId } });
   }
 
-  // alarm 조회 (fcm 토큰 포함)
-  async findAlarm(now: Date) {
-    const alarm = await this.prisma.alarm.findFirst({
+  // 같은 분(minute)에 걸린 알람 전부 조회 (음악 포함)
+  findDueAlarms(from: Date, to: Date) {
+    return this.prisma.alarm.findMany({
       where: {
-        scheduledAt: { lte: now },
+        scheduledAt: { gt: from, lte: to },
         isFired: false,
       },
       include: {
-        user: {
-          include: {
-            deviceTokens: true,
-          },
-        },
+        user: { include: { deviceTokens: true } },
+        music: true, // 음악 메타 데이터
       },
+      orderBy: { scheduledAt: 'asc' },
     });
-
-    return alarm;
   }
 
-  markAsFired(id: number) {
-    return this.prisma.alarm.update({
-      where: { id },
+  // 아직 안 쏜(isFired=false) 건만 true로 바꾸고 카운트 반환
+  async tryMarkFiredOnce(id: number) {
+    const result = await this.prisma.alarm.updateMany({
+      where: { id, isFired: false },
       data: { isFired: true },
     });
+    return result.count; // 1이면 성공(선점), 0이면 이미 다른 프로세스가 처리
   }
 }

--- a/src/alarm/alarm.service.ts
+++ b/src/alarm/alarm.service.ts
@@ -10,6 +10,7 @@ import { UpdateAlarmDto } from './dtos/update-alarm.dto';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { FirebaseAdminService } from 'src/firebase/firebase-admin.service';
 import { nowKST } from 'src/common/functions/time.helper';
+import { AlarmFcmPayload } from './dtos/fcm-payload.dto';
 
 @Injectable()
 export class AlarmService {
@@ -54,30 +55,55 @@ export class AlarmService {
   @Cron(CronExpression.EVERY_MINUTE)
   async processAlarms() {
     const now = nowKST();
+    const from = new Date(now.getTime() - 60_000); // 1분 전 ~ 지금 사이
     // 12월 24일, 25일 Cron 작동하도록 수정하면 됨 -> 주석해제 하면 적용
     // const is24or25 = now.getMonth() === 12 && [24, 25].includes(now.getDate());
     // if (!is24or25) return;
 
     // 조건(현재 시간 && isFired === false)에 맞는 알람이 있는지 검사
-    const alarm = await this.alarmRepository.findAlarm(now);
+    const dueAlarms = await this.alarmRepository.findDueAlarms(from, now);
 
-    if (!alarm) return;
+    if (!dueAlarms.length) return;
 
-    // 하나의 알람에 여러 디바이스 토큰이 있는지 검사
-    const tokens =
-      alarm.user?.deviceTokens?.map((dt) => dt.token).filter(Boolean) ?? [];
+    // 여러 알람을 순회
+    for (const alarm of dueAlarms) {
+      const locked = await this.alarmRepository.tryMarkFiredOnce(alarm.id);
+      if (locked === 0) continue;
 
-    // 한 유저의 모든 디바이스로 알람 발송
-    for (const token of tokens) {
-      // 알림 내용은 여기서 수정하면 됨
-      await this.firebaseAdminService.sendFcm(
-        token,
-        '알람 도착!',
-        '지정된 시간에 도달했어요 ⏰',
-      );
+      // 유저가 가진 토큰들 조회
+      const tokens =
+        alarm.user?.deviceTokens?.map((dt) => dt.token).filter(Boolean) ?? [];
 
-      // 전송된 알람은 isFired 상태 false -> true 로 변경
-      await this.alarmRepository.markAsFired(alarm.id);
+      if (tokens.length === 0) {
+        // 토큰이 없으면 알림 보낼 곳이 없는 상태. 로그만 남겨도 OK.
+        continue;
+      }
+
+      // 전송 실패 시 재시도 큐는 추후 개발예정.....
+
+      const dataPayload: AlarmFcmPayload = {
+        type: 'ALARM',
+        alarmId: String(alarm.id),
+        musicId: String(alarm.musicId),
+        musicTitle: alarm.music?.title ?? '',
+        musicArtist: alarm.music?.artist ?? '',
+        scheduledAt: alarm.scheduledAt.toISOString(),
+      };
+
+      for (const token of tokens) {
+        await this.firebaseAdminService.sendFcm(
+          token,
+          '메리 크리스마스! 🌲',
+          '지정된 시간에 도달했어요.⏰ 메리메리 크리스마스 ~',
+          dataPayload,
+        );
+        console.log(
+          token,
+          '메리 크리스마스! 🌲',
+          '지정된 시간에 도달했어요.⏰ 메리메리 크리스마스 ~',
+          dataPayload,
+        );
+      }
     }
   }
 }

--- a/src/alarm/alarm.swagger.ts
+++ b/src/alarm/alarm.swagger.ts
@@ -107,12 +107,6 @@ export const ApiAlarm = {
       ApiOperation({ summary: '본인 알람 삭제' }),
       ApiOkResponse({
         description: '삭제 성공',
-        schema: {
-          example: {
-            deleted: true,
-            affected: 1,
-          },
-        },
       }),
       ApiNotFoundResponse({ description: '알람 없음' }),
     ),

--- a/src/alarm/dtos/create-alarm.dto.ts
+++ b/src/alarm/dtos/create-alarm.dto.ts
@@ -1,8 +1,13 @@
-import { IsDateString } from 'class-validator';
+import { IsDateString, IsInt, Min } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateAlarmDto {
   @ApiProperty({ example: '2025-12-24T08:10:00Z' })
   @IsDateString()
   scheduledAt: string;
+
+  @ApiProperty({ example: 1, description: '선택한 음악의 기본키(Music.id)' })
+  @IsInt()
+  @Min(1)
+  musicId: number;
 }

--- a/src/alarm/dtos/fcm-payload.dto.ts
+++ b/src/alarm/dtos/fcm-payload.dto.ts
@@ -1,0 +1,8 @@
+export interface AlarmFcmPayload {
+  type: 'ALARM';
+  alarmId: string;
+  musicId: string;
+  musicTitle: string;
+  musicArtist: string;
+  scheduledAt: string;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { AlarmModule } from './alarm/alarm.module';
 import { FcmTokenModule } from './fcm-token/fcm-token.module';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ImagePresignModule } from './image/image-presign.module';
+import { MusicModule } from './music/music.module';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { ImagePresignModule } from './image/image-presign.module';
     AlarmModule,
     FcmTokenModule,
     ImagePresignModule,
+    MusicModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { AdminModule } from './admin/admin.module';
 import { AlarmModule } from './alarm/alarm.module';
 import { FcmTokenModule } from './fcm-token/fcm-token.module';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ImagePresignModule } from './image/image-presign.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     AdminModule,
     AlarmModule,
     FcmTokenModule,
+    ImagePresignModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/types/image.types.ts
+++ b/src/common/types/image.types.ts
@@ -1,0 +1,6 @@
+// 이건 필요할까봐 만들었었는데 지금 안쓰이네요, 필요없으면 나중에 삭제하겠습니다.
+
+export type WithImageKey = { imageUrl?: string | null };
+export type WithSignedUrl<T extends WithImageKey> = T & {
+  signedImageUrl?: string;
+};

--- a/src/fcm-token/fcm-token.controller.ts
+++ b/src/fcm-token/fcm-token.controller.ts
@@ -53,4 +53,8 @@ export class FcmTokenController {
     const userId: number = req.user.id;
     return this.fcmTokenService.register(userId, dto.token, dto.platform);
   }
+
+  // 다시 보면서 생각하면 token 값을 path에서 빼야 좋아보이고,
+  // -> 다른 방식으로 토큰값을 넘기는게 좋아보임 (25.09.04)
+  // put API 는 필요없어 보임 (POST API와 같은 역할)
 }

--- a/src/fcm-token/fcm-token.controller.ts
+++ b/src/fcm-token/fcm-token.controller.ts
@@ -15,8 +15,8 @@ import { RegisterFcmTokenDto } from './dtos/register-fcm-token.dto';
 import { TokenParamDto } from './dtos/token-param.dto';
 import { ApiTags } from '@nestjs/swagger';
 
-@Controller('fcm-token')
-@ApiTags('fcm-token')
+@Controller('fcm-tokens')
+@ApiTags('fcm-tokens')
 @ApiFcmToken.auth()
 @UseGuards(FirebaseAuthGuard)
 export class FcmTokenController {
@@ -57,4 +57,5 @@ export class FcmTokenController {
   // 다시 보면서 생각하면 token 값을 path에서 빼야 좋아보이고,
   // -> 다른 방식으로 토큰값을 넘기는게 좋아보임 (25.09.04)
   // put API 는 필요없어 보임 (POST API와 같은 역할)
+  // fcm 토큰은 그렇게 민감한 정보가 담기지 않아서 그냥 path로 넘기기로 결정 (09.13)
 }

--- a/src/firebase/firebase-admin.service.ts
+++ b/src/firebase/firebase-admin.service.ts
@@ -2,6 +2,7 @@ import * as admin from 'firebase-admin';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import axios from 'axios';
+import { AlarmFcmPayload } from 'src/alarm/dtos/fcm-payload.dto';
 
 @Injectable()
 export class FirebaseAdminService {
@@ -37,7 +38,12 @@ export class FirebaseAdminService {
   }
 
   /** fcm 발송 메서드 */
-  async sendFcm(token: string, title: string, message: string) {
+  async sendFcm(
+    token: string,
+    title: string,
+    message: string,
+    data?: AlarmFcmPayload,
+  ) {
     const payload = {
       token,
       notification: {
@@ -45,7 +51,14 @@ export class FirebaseAdminService {
         body: message,
       },
       data: {
+        ...data,
         body: message,
+      },
+      android: {
+        priority: 'high' as const,
+      },
+      apns: {
+        headers: { 'apns-priority': '10' },
       },
     };
 

--- a/src/image/image-presign.module.ts
+++ b/src/image/image-presign.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ImagePresignService } from './image-presign.service';
+import { S3Module } from 'src/s3/s3.module';
+
+@Module({
+  imports: [S3Module],
+  providers: [ImagePresignService],
+  exports: [ImagePresignService],
+})
+export class ImagePresignModule {}

--- a/src/image/image-presign.service.ts
+++ b/src/image/image-presign.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { S3Service } from 'src/s3/s3.service';
+
+// keySelector: 행에서 S3 키를 어떻게 뽑을지
+// outProp: 주입할 필드명 (기본: "signedImageUrl")
+// deriveKey: 원본 key -> 썸네일 key로 바꾸고 싶을 때 사용 // *이건 일단 안쓰는중.
+type AttachOpts<T> = {
+  keySelector: (row: T) => string | null | undefined;
+  outProp?: string; // 기본 "signedImageUrl"
+  ttlSec?: number;
+  deriveKey?: (key: string, row: T) => string;
+};
+
+@Injectable()
+export class ImagePresignService {
+  constructor(private readonly s3: S3Service) {}
+
+  /**
+   * s3 이미지를 여러개 가져올때 사용함
+   */
+  async attachSignedUrls<T>(
+    rows: T[],
+    opts: AttachOpts<T>,
+  ): Promise<(T & Record<string, string | undefined>)[]> {
+    const { keySelector, outProp = 'signedImageUrl', deriveKey, ttlSec } = opts;
+
+    // 1) 각 행 기준으로 effectiveKey(파생키 또는 원본키) 계산
+    const effectiveKeysPerRow: Array<string | undefined> = rows.map((row) => {
+      const key = keySelector(row);
+      if (!key) return undefined;
+      return deriveKey ? deriveKey(key, row) : key;
+    });
+
+    // 2) 유효한 키만 모아 중복 제거
+    const uniqueKeys = Array.from(
+      new Set(effectiveKeysPerRow.filter((k): k is string => !!k)),
+    );
+    if (uniqueKeys.length === 0) return rows as any;
+
+    // 3) 배치 presign (key -> url 맵)
+    const map = await this.s3.generateGetObjectPresignedUrls(uniqueKeys, {
+      expiresInSec: ttlSec,
+    });
+
+    // 4) 각 행에 주입
+    return rows.map((row, idx) => {
+      const effKey = effectiveKeysPerRow[idx];
+      const url = effKey ? map[effKey] : undefined;
+      return url ? { ...(row as any), [outProp]: url } : row;
+    });
+  }
+}

--- a/src/letter/letter.controller.ts
+++ b/src/letter/letter.controller.ts
@@ -22,6 +22,7 @@ import { FirebaseAuthGuard } from 'src/auth/firebase-auth.guard';
 export class LetterController {
   constructor(private readonly letterService: LetterService) {}
 
+  // 편지 전송과 임시저장은 req에서 userId를 빼서 조회하도록 리팩토링 예정 (09.10)
   /** 편지 전송 */
   @Post()
   @UseGuards(FirebaseAuthGuard)
@@ -36,16 +37,6 @@ export class LetterController {
   @ApiLetters.saveDraft()
   async saveWriting(@Body() saveWritingDto: SaveWritingDto) {
     return this.letterService.saveWriting(saveWritingDto);
-  }
-
-  /** 자신의 전체 편지 조회*/
-  @Get()
-  @UseGuards(FirebaseAuthGuard)
-  @ApiLetters.findAll()
-  async findLetters(@Req() req: any) {
-    const userId = req.user.id;
-
-    return this.letterService.findLetters(userId);
   }
 
   /** 내 사서함 확인 */

--- a/src/letter/letter.module.ts
+++ b/src/letter/letter.module.ts
@@ -4,9 +4,10 @@ import { LetterService } from './letter.service';
 import { LetterRepository } from './letter.repository';
 import { UsersModule } from 'src/users/users.module';
 import { S3Module } from 'src/s3/s3.module';
+import { ImagePresignModule } from 'src/image/image-presign.module';
 
 @Module({
-  imports: [UsersModule, S3Module],
+  imports: [UsersModule, S3Module, ImagePresignModule],
   controllers: [LetterController],
   providers: [LetterService, LetterRepository],
   exports: [LetterService],

--- a/src/letter/letter.repository.ts
+++ b/src/letter/letter.repository.ts
@@ -45,7 +45,7 @@ export class LetterRepository {
     return this.prisma.letter.findUnique({ where: { id: letterId } });
   }
 
-  /** userId로 편지들 조회 */
+  /** userId로 보낸 편지들 조회 */
   findLettersById(userId: number) {
     return this.prisma.letter.findMany({ where: { senderId: userId } });
   }

--- a/src/letter/letter.service.ts
+++ b/src/letter/letter.service.ts
@@ -4,12 +4,14 @@ import { SendLetterDto } from './dtos/send-letter.dto';
 import { SaveWritingDto } from './dtos/save-writing.dto';
 import { S3Service } from 'src/s3/s3.service';
 import { LetterStatusValue } from 'src/common/enums/letter-status.enum';
+import { ImagePresignService } from 'src/image/image-presign.service';
 
 @Injectable()
 export class LetterService {
   constructor(
     private readonly letterRepository: LetterRepository,
     private readonly s3Service: S3Service,
+    private readonly imagePresignService: ImagePresignService,
   ) {}
 
   /** 실제 전송, status: sent, sentAt 기록 */
@@ -33,7 +35,7 @@ export class LetterService {
 
     let updatedLetter = letter;
 
-    // 내가 받은 편지이고, 상태가 SENT 라면
+    // 내가 받은 편지이고, 상태가 SENT 라면 -> RECEIVED로 변경
     if (
       letter.receiverId === userId &&
       letter.status === LetterStatusValue.SENT
@@ -51,11 +53,20 @@ export class LetterService {
     return { updatedLetter, presignedUrl };
   }
 
-  /** 전체 조회 */
+  /** 보낸 편지 전체 조회 */
   async findLetters(userId: number) {
+    // senderId가 자신인 편지들 조회
     const letters = await this.letterRepository.findLettersById(userId);
+    const lettersWithPresign = await this.imagePresignService.attachSignedUrls(
+      letters,
+      {
+        keySelector: (r) => r.imageUrl,
+        outProp: 'signedImageUrl', // 기본값이라 생략 가능
+        ttlSec: 300,
+      },
+    );
 
-    return letters;
+    return { lettersWithPresign };
   }
 
   /** 내 사서함 확인 */
@@ -65,7 +76,17 @@ export class LetterService {
 
   /** 보낸 편지함 확인 */
   async findSentLetters(userId: number) {
-    return this.letterRepository.findSentLetters(userId);
+    const letters = await this.letterRepository.findSentLetters(userId);
+    const lettersWithPresign = await this.imagePresignService.attachSignedUrls(
+      letters,
+      {
+        keySelector: (r) => r.imageUrl,
+        outProp: 'signedImageUrl', // 기본값이라 생략 가능
+        ttlSec: 300,
+      },
+    );
+
+    return { lettersWithPresign };
   }
 
   /** 임시 보관함 확인 */

--- a/src/letter/letter.service.ts
+++ b/src/letter/letter.service.ts
@@ -62,7 +62,7 @@ export class LetterService {
       {
         keySelector: (r) => r.imageUrl,
         outProp: 'signedImageUrl', // 기본값이라 생략 가능
-        ttlSec: 300,
+        ttlSec: 300, // 나중에 상수값으로 변경하겠습니다 (09.10)
       },
     );
 
@@ -82,7 +82,7 @@ export class LetterService {
       {
         keySelector: (r) => r.imageUrl,
         outProp: 'signedImageUrl', // 기본값이라 생략 가능
-        ttlSec: 300,
+        ttlSec: 300, // 나중에 상수값으로 변경하겠습니다 (09.10)
       },
     );
 

--- a/src/music/dtos/create-music.dto.ts
+++ b/src/music/dtos/create-music.dto.ts
@@ -1,0 +1,14 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateMusicDto {
+  @ApiProperty({ example: 'Jingle Bells (Instrumental)' })
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({ example: 'Jingle Punks' })
+  @IsString()
+  @IsNotEmpty()
+  artist: string;
+}

--- a/src/music/dtos/res-music.dto.ts
+++ b/src/music/dtos/res-music.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResMusicDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'Jingle Bells (Instrumental)' })
+  title: string;
+
+  @ApiProperty({ example: 'Jingle Punks' })
+  artist: string;
+
+  @ApiProperty({ example: '2025-09-24T12:34:56.000Z' })
+  createdAt: string;
+}

--- a/src/music/dtos/update-music.dto.ts
+++ b/src/music/dtos/update-music.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateMusicDto } from './create-music.dto';
+
+export class UpdateMusicDto extends PartialType(CreateMusicDto) {}

--- a/src/music/music.controller.ts
+++ b/src/music/music.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Put,
+  Delete,
+  ParseIntPipe,
+  HttpCode,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { MusicService } from './music.service';
+import { CreateMusicDto } from './dtos/create-music.dto';
+import { UpdateMusicDto } from './dtos/update-music.dto';
+import { ApiMusics } from './music.swagger';
+// import { FirebaseAuthGuard } from '../auth/firebase-auth.guard';
+
+@Controller('musics')
+@ApiTags('musics')
+// @UseGuards(FirebaseAuthGuard) // 여기는 admin 가드로 추후 변경 (09.16)
+export class MusicController {
+  constructor(private readonly musicService: MusicService) {}
+
+  @Get()
+  @ApiMusics.findAll()
+  list() {
+    return this.musicService.list();
+  }
+
+  @Get(':musicId')
+  @ApiMusics.findOne()
+  get(@Param('musicId', ParseIntPipe) musicId: number) {
+    return this.musicService.get(musicId);
+  }
+
+  @Post()
+  @ApiMusics.create()
+  create(@Body() dto: CreateMusicDto) {
+    return this.musicService.create(dto);
+  }
+
+  @Put(':musicId')
+  @ApiMusics.update()
+  update(
+    @Param('musicId', ParseIntPipe) musicId: number,
+    @Body() dto: UpdateMusicDto,
+  ) {
+    return this.musicService.update(musicId, dto);
+  }
+
+  // 삭제시 해당 음악을 참조 중인 alarm이 없는지 확인하기.
+  @Delete(':musicId')
+  @HttpCode(204)
+  @ApiMusics.remove()
+  remove(@Param('musicId', ParseIntPipe) musicId: number) {
+    return this.musicService.remove(musicId);
+  }
+}

--- a/src/music/music.module.ts
+++ b/src/music/music.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { MusicService } from './music.service';
+import { MusicRepository } from './music.repository';
+import { MusicController } from './music.controller';
+import { UsersModule } from 'src/users/users.module';
+
+@Module({
+  imports: [UsersModule],
+  controllers: [MusicController],
+  providers: [MusicService, MusicRepository],
+})
+export class MusicModule {}

--- a/src/music/music.repository.ts
+++ b/src/music/music.repository.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { Music, Prisma } from '@prisma/client';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class MusicRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findMany(params?: Prisma.MusicFindManyArgs): Promise<Music[]> {
+    return this.prisma.music.findMany(params);
+  }
+
+  findById(id: number): Promise<Music | null> {
+    return this.prisma.music.findUnique({ where: { id } });
+  }
+
+  create(data: Prisma.MusicCreateInput): Promise<Music> {
+    return this.prisma.music.create({ data });
+  }
+
+  update(id: number, data: Prisma.MusicUpdateInput): Promise<Music> {
+    return this.prisma.music.update({ where: { id }, data });
+  }
+
+  delete(id: number): Promise<Music> {
+    return this.prisma.music.delete({ where: { id } });
+  }
+}

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { MusicRepository } from './music.repository';
+import { CreateMusicDto } from './dtos/create-music.dto';
+import { UpdateMusicDto } from './dtos/update-music.dto';
+
+@Injectable()
+export class MusicService {
+  constructor(private readonly musicRepo: MusicRepository) {}
+
+  async list() {
+    return this.musicRepo.findMany({
+      orderBy: { id: 'asc' },
+      select: { id: true, title: true, artist: true, createdAt: true },
+    });
+  }
+
+  async get(id: number) {
+    const music = await this.musicRepo.findById(id);
+    if (!music) throw new NotFoundException('Music not found');
+    return music;
+  }
+
+  async create(dto: CreateMusicDto) {
+    return this.musicRepo.create({
+      title: dto.title,
+      artist: dto.artist,
+    });
+  }
+
+  async update(id: number, dto: UpdateMusicDto) {
+    const exists = await this.musicRepo.findById(id);
+    if (!exists) throw new NotFoundException('Music not found');
+    return this.musicRepo.update(id, {
+      ...(dto.title ? { title: dto.title } : {}),
+      ...(dto.artist ? { artist: dto.artist } : {}),
+    });
+  }
+
+  async remove(id: number) {
+    const exists = await this.musicRepo.findById(id);
+    if (!exists) throw new NotFoundException('Music not found');
+    return this.musicRepo.delete(id);
+  }
+}

--- a/src/music/music.swagger.ts
+++ b/src/music/music.swagger.ts
@@ -1,0 +1,151 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { CreateMusicDto } from './dtos/create-music.dto';
+import { UpdateMusicDto } from './dtos/update-music.dto';
+import { ResMusicDto } from './dtos/res-music.dto';
+
+export const ApiMusics = {
+  findAll: () =>
+    applyDecorators(
+      ApiOperation({ summary: '음악 목록 조회' }),
+      ApiResponse({
+        status: 200,
+        type: ResMusicDto,
+        isArray: true,
+        description: '등록된 음악 전체 목록을 반환합니다.',
+      }),
+    ),
+
+  findOne: () =>
+    applyDecorators(
+      ApiOperation({ summary: '음악 단건 조회' }),
+      ApiResponse({
+        status: 200,
+        type: ResMusicDto,
+        description: '단일 음악 조회 성공',
+      }),
+      ApiResponse({
+        status: 404,
+        description: '해당 ID의 음악이 존재하지 않음',
+        content: {
+          'application/json': {
+            example: {
+              statusCode: 404,
+              message: 'Music not found',
+              error: 'Not Found',
+            },
+          },
+        },
+      }),
+    ),
+
+  create: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '음악 생성',
+        description: '새로운 정적 음악 메타데이터를 생성합니다.',
+      }),
+      ApiBody({ type: CreateMusicDto }),
+      ApiResponse({
+        status: 201,
+        type: ResMusicDto,
+        description: '음악이 성공적으로 생성되었습니다.',
+        content: {
+          'application/json': {
+            example: {
+              id: 3,
+              title: '피아노 멜로디',
+              artist: '알람 사운드',
+              createdAt: '2025-09-10T12:34:56.000Z',
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 400,
+        description: '유효하지 않은 입력 값',
+        content: {
+          'application/json': {
+            example: {
+              statusCode: 400,
+              message: ['title should not be empty', 'artist must be a string'],
+              error: 'Bad Request',
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 409,
+        description: '중복 등으로 인한 생성 실패(정책에 따라)',
+        content: {
+          'application/json': {
+            example: {
+              statusCode: 409,
+              message: '이미 존재하는 제목입니다.',
+              error: 'Conflict',
+            },
+          },
+        },
+      }),
+    ),
+
+  update: () =>
+    applyDecorators(
+      ApiOperation({ summary: '음악 수정' }),
+      ApiBody({ type: UpdateMusicDto }),
+      ApiResponse({
+        status: 200,
+        type: ResMusicDto,
+        description: '음악 정보가 성공적으로 수정되었습니다.',
+      }),
+      ApiResponse({
+        status: 400,
+        description: '유효하지 않은 입력 값',
+      }),
+      ApiResponse({
+        status: 404,
+        description: '해당 ID의 음악이 존재하지 않음',
+        content: {
+          'application/json': {
+            example: {
+              statusCode: 404,
+              message: 'Music not found',
+              error: 'Not Found',
+            },
+          },
+        },
+      }),
+    ),
+
+  remove: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '음악 삭제',
+        description:
+          '음악을 삭제합니다. 알람에서 참조 중인 경우 정책에 따라 실패할 수 있습니다.',
+      }),
+      ApiResponse({
+        status: 204,
+        description: '삭제된 음악 정보를 반환합니다.',
+      }),
+      ApiResponse({
+        status: 404,
+        description: '해당 ID의 음악이 존재하지 않음',
+      }),
+      ApiResponse({
+        status: 409,
+        description:
+          'FK 제약 등으로 삭제 불가(예: 알람이 참조 중). 운영 정책에 따라 문구 조정',
+        content: {
+          'application/json': {
+            example: {
+              statusCode: 409,
+              message:
+                'This music is referenced by alarms and cannot be deleted.',
+              error: 'Conflict',
+            },
+          },
+        },
+      }),
+    ),
+};

--- a/src/s3/constants/s3.constant.ts
+++ b/src/s3/constants/s3.constant.ts
@@ -1,4 +1,6 @@
 export const S3Folder = {
   LETTERS: 'letters',
   GIFTS: 'gifts',
+  COVERS: 'covers',
+  MUSICS: 'musics',
 } as const;

--- a/src/s3/s3.controller.ts
+++ b/src/s3/s3.controller.ts
@@ -42,11 +42,43 @@ export class S3Controller {
   @UseGuards(FirebaseAuthGuard)
   @ApiS3.getPresignedUrl('gift')
   async getGiftPresignedUrl(
-    @Req() req: any,
     @Query('filename') filename: string,
     @Query('contentType') contentType: string,
   ) {
     const result = await this.s3Service.generateGiftImagePresignedUrl(
+      filename,
+      contentType,
+    );
+
+    return result;
+  }
+
+  // 음악 관련 메서드는 안 쓰일 것 같음.. (음악파일과 표지를 앱자체에 저장시키기로 함-09.14)
+  /** 음악 표지 업로드용 presigned URL 발급 */
+  @Get('cover-presigned-url')
+  @UseGuards(FirebaseAuthGuard)
+  @ApiS3.getPresignedUrl('cover')
+  async getCoverPresignedUrl(
+    @Query('filename') filename: string,
+    @Query('contentType') contentType: string,
+  ) {
+    const result = await this.s3Service.generateCoverImagePresignedUrl(
+      filename,
+      contentType,
+    );
+
+    return result;
+  }
+
+  /** 음악(mp3) 업로드용 presigned URL 발급 */
+  @Get('music-presigned-url')
+  @UseGuards(FirebaseAuthGuard)
+  @ApiS3.getPresignedUrl('music')
+  async getMusicPresignedUrl(
+    @Query('filename') filename: string,
+    @Query('contentType') contentType: string,
+  ) {
+    const result = await this.s3Service.generateMusicPresignedUrl(
       filename,
       contentType,
     );

--- a/src/s3/s3.service.ts
+++ b/src/s3/s3.service.ts
@@ -74,6 +74,40 @@ export class S3Service {
     return this.generatePresignedUrl(key, contentType);
   }
 
+  /** 음악 표지 업로드 url 생성 함수 */
+  async generateCoverImagePresignedUrl(
+    originalFileName: string,
+    contentType: string,
+  ): Promise<{ url: string; key: string }> {
+    const ext = path.extname(originalFileName);
+    if (!ext) {
+      throw new Error('Invalid file extension');
+    }
+
+    const uuid = uuidv4();
+
+    const key = `${S3Folder.COVERS}/${uuid}${ext}`;
+
+    return this.generatePresignedUrl(key, contentType);
+  }
+
+  /** 음악(mp3) 업로드 url 생성 함수 */
+  async generateMusicPresignedUrl(
+    originalFileName: string,
+    contentType: string,
+  ): Promise<{ url: string; key: string }> {
+    const ext = path.extname(originalFileName);
+    if (!ext) {
+      throw new Error('Invalid file extension');
+    }
+
+    const uuid = uuidv4();
+
+    const key = `${S3Folder.MUSICS}/${uuid}${ext}`;
+
+    return this.generatePresignedUrl(key, contentType);
+  }
+
   /** 이미지 열람용 presigned URL 생성 */
   async generateGetObjectPresignedUrl(key: string): Promise<string> {
     const command = new GetObjectCommand({

--- a/src/s3/s3.service.ts
+++ b/src/s3/s3.service.ts
@@ -22,6 +22,10 @@ export class S3Service {
     },
   });
 
+  private get bucket() {
+    return this.configService.get<string>('AWS_S3_BUCKET');
+  }
+
   private async generatePresignedUrl(key: string, contentType: string) {
     const command = new PutObjectCommand({
       Bucket: this.configService.get<string>('AWS_S3_BUCKET'),
@@ -79,6 +83,45 @@ export class S3Service {
 
     const url = await getSignedUrl(this.s3Client, command, { expiresIn: 300 }); // 5분 유효
     return url;
+  }
+
+  /** 여러 이미지 열람용 presigned URL 배치 생성 */
+  async generateGetObjectPresignedUrls(
+    keys: string[],
+    opts?: { expiresInSec?: number; concurrency?: number },
+  ): Promise<Record<string, string>> {
+    const expiresInSec = opts?.expiresInSec ?? 300;
+
+    // 유효한 키만 모아 중복 제거
+    const uniqueKeys = Array.from(
+      new Set(keys.filter((k): k is string => !!k)),
+    );
+    if (uniqueKeys.length === 0) return {};
+
+    // presign 병렬 처리
+    const entries = await Promise.all(
+      uniqueKeys.map(async (key) => {
+        try {
+          const command = new GetObjectCommand({
+            Bucket: this.bucket,
+            Key: key,
+          });
+          const url = await getSignedUrl(this.s3Client, command, {
+            expiresIn: expiresInSec,
+          });
+          return [key, url] as const;
+        } catch {
+          // 실패하면 undefined로 표시해 두고 아래에서 필터
+          return [key, undefined] as const;
+        }
+      }),
+    );
+
+    // { [key]: url } 형태로 변환(성공한 것만)
+    return Object.fromEntries(entries.filter(([, url]) => !!url)) as Record<
+      string,
+      string
+    >;
   }
 
   /** s3 이미지들 삭제 */

--- a/src/s3/s3.swagger.ts
+++ b/src/s3/s3.swagger.ts
@@ -2,7 +2,7 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
 
 export const ApiS3 = {
-  getPresignedUrl: (label: 'letter' | 'gift') =>
+  getPresignedUrl: (label: 'letter' | 'gift' | 'cover' | 'music') =>
     applyDecorators(
       ApiOperation({
         summary: `${label} 이미지 업로드용 Presigned URL 발급`,
@@ -18,7 +18,7 @@ export const ApiS3 = {
         name: 'contentType',
         required: true,
         description: '업로드할 파일의 Content-Type',
-        example: 'image/jpeg',
+        example: 'image/jpg',
       }),
       ApiResponse({
         status: 200,


### PR DESCRIPTION
## #️⃣연관된 이슈

#36

## 📝작업 내용
### 음악 테이블과 CRUD 추가
음악을 s3에 저장하려했으나 음악 수가 6개 뿐이라 앱에 자체적으로 저장하기로 기획이 변경되었습니다
-> 이에 따라 음악테이블에 정적데이터만 추가하고
-> 알람 생성시 어떤 음악 데이터를 포함하는지 로직이 추가되었습니다.

### 알람 로직 변경
기존에 알람이 여러 유저에 대해 검사를 진행하고 있지 않는걸 발견해서
1. 여러 유저의 알람을 검사하고
2. 각 알람에 fcm 토큰이 여러개 있는지 검사하고
3. 각 토큰으로 알람을 발송하도록 수정했습니다.

### 변경된 도메인들
alarm, fcm-token, music 부분이 변경 됐습니다. 
---
s3에 음악을 저장하는 코드들은 무시하고 보셔도 됩니다. ( 나중에 쓰일까봐 + 아까워서 잠시 남겨놓겠습니다. )


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
필요해보이는 로직이 있다면 조언 부탁드립니다.
