### PR TITLE
편지지 ID 값을 추가해서 편지 기능 구현

### DIFF
--- a/prisma/migrations/20251028150944_create_letter_papers_table/migration.sql
+++ b/prisma/migrations/20251028150944_create_letter_papers_table/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - Added the required column `paper_id` to the `letters` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "letters" ADD COLUMN     "paper_id" INTEGER NOT NULL;
+
+-- CreateTable
+CREATE TABLE "letter_papers" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "letter_papers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "letter_papers_name_key" ON "letter_papers"("name");
+
+-- AddForeignKey
+ALTER TABLE "letters" ADD CONSTRAINT "letters_paper_id_fkey" FOREIGN KEY ("paper_id") REFERENCES "letter_papers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,15 +96,28 @@ model Letter {
   receiverId Int?         @map("receiver_id")
   content    String
   imageUrl   String?      @map("image_url")
+  paperId    Int          @map("paper_id")
   status     LetterStatus
   sentAt     DateTime?    @map("sent_at") // 전송 시각, 전송 전엔 NULL
   createdAt  DateTime     @default(now()) @map("created_at")
   updatedAt  DateTime     @updatedAt @map("updated_at")
 
-  sender   User  @relation("SentLetters", fields: [senderId], references: [id])
-  receiver User? @relation("ReceivedLetters", fields: [receiverId], references: [id])
+  sender   User        @relation("SentLetters", fields: [senderId], references: [id])
+  receiver User?       @relation("ReceivedLetters", fields: [receiverId], references: [id])
+  paper    LetterPaper @relation(fields: [paperId], references: [id], onDelete: Restrict)
 
   @@map("letters")
+}
+
+model LetterPaper {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  createdAt DateTime @default(now()) @map("created_at")
+
+  // Letter와의 관계 설정 (Letter 쪽에서 참조)
+  letters Letter[]
+
+  @@map("letter_papers")
 }
 
 model Schedule {

--- a/src/letter/dtos/res-letter.dto.ts
+++ b/src/letter/dtos/res-letter.dto.ts
@@ -13,6 +13,9 @@ export class ResLetterDto {
   @ApiProperty({ example: 44, description: '편지 ID' })
   id: number;
 
+  @ApiProperty({ example: 1, description: '선택된 편지지 ID' })
+  paperId: number;
+
   @ApiProperty({
     example: '안녕하세요, 편지 내용입니다...',
     description: '편지 본문',

--- a/src/letter/dtos/res-send-letter.dto.ts
+++ b/src/letter/dtos/res-send-letter.dto.ts
@@ -8,6 +8,9 @@ export class ResSendLetterDto {
   @ApiProperty({ example: 42 })
   id: number;
 
+  @ApiProperty({ example: 1, description: '선택된 편지지 ID' })
+  paperId: number;
+
   @ApiProperty({ example: 17 })
   senderId: number;
 

--- a/src/letter/dtos/save-writing.dto.ts
+++ b/src/letter/dtos/save-writing.dto.ts
@@ -1,6 +1,6 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { SendLetterDto } from './send-letter.dto';
-import { IsInt, IsOptional, IsString } from 'class-validator';
+import { IsInt, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class SaveWritingDto extends PartialType(SendLetterDto) {
@@ -19,6 +19,14 @@ export class SaveWritingDto extends PartialType(SendLetterDto) {
   @IsOptional()
   @IsInt()
   receiverId?: number;
+
+  @ApiProperty({
+    example: 1,
+    description: '선택된 편지지 ID (필수)',
+  })
+  @IsInt({ message: '편지지 ID는 정수여야 합니다.' })
+  @IsNotEmpty({ message: '편지지 ID는 필수 입력 항목입니다.' })
+  paperId: number;
 
   @ApiProperty({
     example: '이건 저장 중인 편지 내용',

--- a/src/letter/dtos/send-letter.dto.ts
+++ b/src/letter/dtos/send-letter.dto.ts
@@ -16,6 +16,14 @@ export class SendLetterDto {
   @IsInt()
   receiverId?: number;
 
+  @ApiProperty({
+    example: 1,
+    description: '선택된 편지지 ID (필수)',
+  })
+  @IsInt({ message: '편지지 ID는 정수여야 합니다.' })
+  @IsNotEmpty({ message: '편지지 ID는 필수 입력 항목입니다.' })
+  paperId: number;
+
   @ApiProperty({ example: '안녕하세요!', description: '편지 내용' })
   @IsString()
   @IsNotEmpty()

--- a/src/letter/letter.repository.ts
+++ b/src/letter/letter.repository.ts
@@ -16,6 +16,7 @@ const letterSelect = {
   id: true,
   content: true,
   imageUrl: true,
+  paperId: true,
   status: true,
   sentAt: true,
   receiverId: true,
@@ -45,6 +46,7 @@ export class LetterRepository {
       data,
       select: {
         id: true,
+        paperId: true,
         senderId: true,
         receiverId: true,
         status: true,
@@ -62,6 +64,7 @@ export class LetterRepository {
       content: dto.content,
       imageUrl: dto.imageUrl ?? null,
       receiverId: dto.receiverId ?? null,
+      paperId: dto.paperId,
       status: LetterStatusValue.WRITING,
     };
 
@@ -71,6 +74,7 @@ export class LetterRepository {
       receiverId: true,
       content: true,
       imageUrl: true,
+      paperId: true,
       status: true,
       sentAt: true,
     };
@@ -163,7 +167,7 @@ export class LetterRepository {
         id: { in: letterIds },
         senderId: userId, // 또는 senderId
       },
-      select: { id: true, imageUrl: true, status: true },
+      select: { id: true, imageUrl: true, status: true, paperId: true },
     });
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #57

## 📝작업 내용
 - 편지지 id 값을 추가해서 letter 도메인의 엔드포인트들을 수정했습니다.
 - zipCode 값 자동생성도 여기서 하려고 했으나 email 인증 브랜치에서 하는게 낫겠다 싶어서 
 다른 브랜치에서 작업하기로 결정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
