### PR TITLE
회원가입시 zipCode 자동생성 및 닉네임 중복 확인 API 추가

### DIFF
--- a/prisma/migrations/20251029065133_zip_code_add_unique/migration.sql
+++ b/prisma/migrations/20251029065133_zip_code_add_unique/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[zip_code]` on the table `users` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "users_zip_code_key" ON "users"("zip_code");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,7 +54,7 @@ model User {
   email          String?   @unique // (10.13 자체로그인시에만 저장)
   hashedPassword String?   @map("hashed_password") // 자체로그인시 저장
   nickname       String    @unique
-  zipCode        Int       @map("zip_code")
+  zipCode        Int       @unique @map("zip_code")
   loginType      LoginType @default(NATIVE) @map("login_type")
   providerId     String?   @unique @map("provider_id") // 소셜로그인시 저장
   isAdmin        Boolean   @default(false) @map("is_admin")

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -56,7 +56,6 @@ export class AuthController {
   async refresh(
     @Headers('refresh-token') refreshToken: string,
   ): Promise<TokenResponseDto> {
-    // 갱신 토큰을 Body로 받아 서비스로 전달하여 검증 및 재발급 처리
     return this.authService.refreshTokens(refreshToken);
   }
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -27,6 +27,7 @@ import { AuthLoginDto } from './dtos/auth-login.dto';
 import { TokenResponseDto } from './dtos/token-res.dto';
 import { GetUserId } from './decorators/get-user-id.decorator';
 import { AuthGuard } from '@nestjs/passport';
+import { CheckNicknameDto } from './dtos/check-nickname-dto';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -65,6 +66,16 @@ export class AuthController {
   @UseGuards(AuthGuard('accessToken'))
   async logout(@GetUserId() userId: number): Promise<void> {
     await this.authService.logout(userId);
+  }
+
+  // Guard 달지 않아도 됩니다! 회원가입시 닉네임 중복 체크용
+  @Get('native/check-nickname')
+  @ApiAuthNative.checkNickname()
+  @HttpCode(HttpStatus.OK)
+  async checkNickname(
+    @Query() dto: CheckNicknameDto,
+  ): Promise<{ isAvailable: boolean }> {
+    return await this.authService.checkNicknameAvailability(dto.nickname);
   }
 
   /////////// 아래는 소셜로그인 ///////////

--- a/src/auth/auth.repository.ts
+++ b/src/auth/auth.repository.ts
@@ -28,9 +28,21 @@ export class AuthRepository {
     });
   }
 
+  // 회원가입 전 zipCode로 사용자 찾기
+  async findUserByZipCode(zipCode: number): Promise<User | null> {
+    return this.prisma.user.findFirst({
+      where: {
+        zipCode,
+      },
+    });
+  }
+
   // 신규 사용자 생성 (자체 로그인)
   async createUser(
-    data: Omit<AuthRegisterDto, 'password'> & { hashedPassword: string },
+    data: Omit<AuthRegisterDto, 'password'> & {
+      hashedPassword: string;
+      zipCode: number;
+    },
   ): Promise<User> {
     const { email, nickname, zipCode, hashedPassword } = data;
     return this.prisma.user.create({

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -28,7 +28,9 @@ export class AuthService {
     private readonly configService: ConfigService, // 환경변수 사용을 위한 ConfigService
   ) {}
 
-  // JWT 쌍 생성
+  /**
+   * JWT 쌍 생성
+   */
   private async getTokens(user: {
     id: number;
     isAdmin: boolean;
@@ -72,6 +74,25 @@ export class AuthService {
     return { accessToken, refreshToken };
   }
 
+  /**
+   * 고유한 5자리 우편번호를 생성하는 헬퍼 함수
+   */
+  private async generateUniqueZipCode(): Promise<number> {
+    while (true) {
+      // 1. 10000 ~ 99999 사이의 5자리 정수 생성
+      const zipCode = Math.floor(10000 + Math.random() * 90000);
+
+      // 2. DB에서 이 zipCode를 누가 쓰고 있는지 확인
+      const existingUser = await this.authRepository.findUserByZipCode(zipCode);
+
+      // 3. 아무도 안 쓰고 있다면 이 번호 반환
+      if (!existingUser) {
+        return zipCode;
+      }
+      // (if 만약 누군가 쓰고 있다면 {루프가 다시 돌면서 새 번호 생성})
+    }
+  }
+
   // 회원가입
   async register(dto: AuthRegisterDto): Promise<TokenResponseDto> {
     // 1. 이메일, 닉네임 중복 확인
@@ -87,15 +108,23 @@ export class AuthService {
     }
 
     // 2. 비밀번호 해싱
-    const hashedPassword = await bcrypt.hash(dto.password, 10);
+    const hashedPassword = await bcrypt.hash(
+      dto.password,
+      Number(this.configService.get<number>('BCRYPT_SALT_ROUNDS')),
+    );
 
-    // 3. 사용자 생성 (NATIVE 타입으로)
+    // 3. 고유 우편번호 생성
+    const uniqueZipCode = await this.generateUniqueZipCode();
+    console.log(uniqueZipCode);
+
+    // 4. 사용자 생성 (NATIVE 타입으로)
     const newUser = await this.authRepository.createUser({
       ...dto,
       hashedPassword,
+      zipCode: uniqueZipCode,
     });
 
-    // 4. 토큰 발급 및 리프레시 토큰 저장
+    // 5. 토큰 발급 및 리프레시 토큰 저장
     return this.getTokens(newUser);
   }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -209,6 +209,16 @@ export class AuthService {
     await this.authRepository.deleteRefreshToken(userId);
   }
 
+  // 닉네임 사용 가능 여부 확인
+  async checkNicknameAvailability(
+    nickname: string,
+  ): Promise<{ isAvailable: boolean }> {
+    const existingUser = await this.authRepository.findByNickname(nickname);
+
+    // 존재하면 false, 존재하지 않으면 true 반환
+    return { isAvailable: !existingUser };
+  }
+
   /////////// 아래는 소셜로그인 ///////////
 
   // Kakao Access Token -> Firebase Custom Token 발급

--- a/src/auth/auth.swagger.ts
+++ b/src/auth/auth.swagger.ts
@@ -9,6 +9,7 @@ import { applyDecorators } from '@nestjs/common';
 import { TokenResponseDto } from './dtos/token-res.dto';
 import { AuthLoginDto } from './dtos/auth-login.dto';
 import { AuthRegisterDto } from './dtos/auth-register.dto';
+import { ResCheckNicknameDto } from './dtos/res-check-nickname.dto';
 
 export function SwaggerKakaoLogin() {
   return applyDecorators(
@@ -193,6 +194,32 @@ export const ApiAuthNative = {
       ApiResponse({
         status: 401,
         description: '인증 실패 (유효하지 않은 Access Token)',
+      }),
+    ),
+  checkNickname: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '[네이티브] 닉네임 중복 확인',
+        description:
+          '회원가입 시 사용할 닉네임이 중복되었는지 확인합니다. (Public API)',
+      }),
+      ApiResponse({
+        status: 200,
+        description: '확인 성공 (true: 사용 가능, false: 중복)',
+        type: ResCheckNicknameDto, // 👈 [1] 에서 만든 응답 DTO
+      }),
+      ApiResponse({
+        status: 400,
+        description: '유효성 검사 실패 (닉네임 형식 오류)',
+        schema: {
+          example: {
+            message: [
+              '닉네임은 2~8자의 한글, 영어, 숫자만 사용 가능하며, 공백, 특수문자, 이모티콘은 허용되지 않습니다.',
+            ],
+            error: 'Bad Request',
+            statusCode: 400,
+          },
+        },
       }),
     ),
 };

--- a/src/auth/dtos/auth-register.dto.ts
+++ b/src/auth/dtos/auth-register.dto.ts
@@ -41,10 +41,4 @@ export class AuthRegisterDto {
       '닉네임은 2~8자의 한글, 영어, 숫자만 사용 가능하며, 공백, 특수문자, 이모티콘은 허용되지 않습니다.',
   })
   nickname: string;
-
-  @ApiProperty({ example: 20850, description: '우편번호' })
-  @IsInt({ message: '우편번호는 정수여야 합니다.' })
-  @Min(10000, { message: '유효하지 않은 우편번호 형식입니다.' })
-  @Max(99999, { message: '유효하지 않은 우편번호 형식입니다.' })
-  zipCode: number;
 }

--- a/src/auth/dtos/check-nickname-dto.ts
+++ b/src/auth/dtos/check-nickname-dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+
+export class CheckNicknameDto {
+  @ApiProperty({
+    example: '루돌이',
+    description: '중복 확인할 닉네임 (2~8자, 한글/영문/숫자)',
+  })
+  @IsString({ message: '닉네임은 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: '닉네임은 필수 입력 항목입니다.' })
+  @Matches(/^[가-힣a-zA-Z0-9]{2,8}$/, {
+    message:
+      '닉네임은 2~8자의 한글, 영어, 숫자만 사용 가능하며, 공백, 특수문자, 이모티콘은 허용되지 않습니다.',
+  })
+  nickname: string;
+}

--- a/src/auth/dtos/res-check-nickname.dto.ts
+++ b/src/auth/dtos/res-check-nickname.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResCheckNicknameDto {
+  @ApiProperty({
+    example: true,
+    description: '닉네임 사용 가능 여부 (true: 사용 가능, false: 중복)',
+    type: Boolean,
+  })
+  isAvailable: boolean;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -34,7 +34,7 @@ export class UsersController {
   //   return this.usersService.getUserInfoByProviderId(uid);
   // }
 
-  @Get('zipCode')
+  @Get('zipcode')
   @UseGuards(AuthGuard('accessToken'))
   @SwaggerFindUserByZipcode()
   async findUsersByZipCode(


### PR DESCRIPTION
## #️⃣연관된 이슈

- #59

## 📝작업 내용

<img width="637" height="267" alt="image" src="https://github.com/user-attachments/assets/3c69f1d5-3dbc-45e6-a52a-fe8b1cbbf0e7" />

- 중복확인 API가 추가 되었고
- 회원가입시 zipCode 값을 받지 않도록 변경했습니다.
- DB 상으로는 user테이블 zipCode에 unique 제약을 추가했습니다.

## 💬리뷰 요구사항(선택)
