### PR TITLE
산타유저(12025)에게 편지를 못 보내도록 수정

### DIFF
--- a/src/auth/auth-naitve/auth-native.repository.ts
+++ b/src/auth/auth-naitve/auth-native.repository.ts
@@ -35,6 +35,13 @@ export class AuthNativeRepository {
     });
   }
 
+  // providerId로 사용자 찾기
+  async findByProviderId(providerId: string): Promise<User | null> {
+    return this.prisma.user.findUnique({
+      where: { providerId: providerId },
+    });
+  }
+
   // 신규 사용자 생성 (자체 로그인)
   async createUser(
     data: Omit<AuthRegisterDto, 'password'> & {
@@ -166,7 +173,7 @@ export class AuthNativeRepository {
     });
   }
 
-  // 사용자 삭제
+  // 사용자 삭제 (탈퇴시 사용)
   async deleteUserById(userId: number): Promise<void> {
     await this.prisma.user.delete({
       where: { id: userId },

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -37,6 +37,12 @@ import { AuthNativeRepository } from './auth-naitve/auth-native.repository';
     JWTAdminGuard,
   ],
   controllers: [AuthController, AuthNativeController],
-  exports: [FirebaseAuthGuard, UsersModule, AccessTokenGuard, JWTAdminGuard],
+  exports: [
+    UsersModule,
+    AuthNativeRepository,
+    FirebaseAuthGuard,
+    AccessTokenGuard,
+    JWTAdminGuard,
+  ],
 })
 export class AuthModule {}

--- a/src/letter/letter.module.ts
+++ b/src/letter/letter.module.ts
@@ -6,11 +6,12 @@ import { UsersModule } from 'src/users/users.module';
 import { S3Module } from 'src/s3/s3.module';
 import { ImagePresignModule } from 'src/image/image-presign.module';
 import { AuthModule } from 'src/auth/auth.module';
+import { SantaUserIdProvider } from './santa-user-id.provider';
 
 @Module({
   imports: [UsersModule, S3Module, ImagePresignModule, AuthModule],
   controllers: [LetterController],
-  providers: [LetterService, LetterRepository],
+  providers: [LetterService, LetterRepository, SantaUserIdProvider],
   exports: [LetterService],
 })
 export class LetterModule {}

--- a/src/letter/letter.service.ts
+++ b/src/letter/letter.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -8,30 +9,37 @@ import { SendLetterDto } from './dtos/send-letter.dto';
 import { SaveWritingDto } from './dtos/save-writing.dto';
 import { S3Service } from 'src/s3/s3.service';
 import { LetterStatusValue } from 'src/common/enums/letter-status.enum';
-import { ImagePresignService } from 'src/image/image-presign.service';
 import { ResSendLetterDto } from './dtos/res-send-letter.dto';
 import { ResDraftLetterDto } from './dtos/res-draft-letter.dto';
 import { ResReceivedLetterDto } from './dtos/res-received-letter.dto';
 import { ResSentLetterDto } from './dtos/res-sent-letter.dto';
 import { ResDraftLetterItemDto } from './dtos/res-draft-letter-item.dto';
 import { ResLetterDto } from './dtos/res-letter.dto';
+import { SANTA_USER_ID } from './santa-user-id.provider';
 
 @Injectable()
 export class LetterService {
   constructor(
     private readonly letterRepository: LetterRepository,
     private readonly s3Service: S3Service,
-    private readonly imagePresignService: ImagePresignService,
-  ) {}
+    @Inject(SANTA_USER_ID) private readonly santaUserId: number,
+  ) {
+    console.log(`LetterService initialized with Santa ID: ${this.santaUserId}`);
+  }
 
   /** 실제 전송, status: sent, sentAt 기록 */
   async sendLetter(
-    userId: number,
+    senderId: number,
     sendLetterDto: SendLetterDto,
   ): Promise<ResSendLetterDto> {
+    // 산타에게 편지 보내기 차단
+    if (sendLetterDto.receiverId === this.santaUserId) {
+      throw new BadRequestException('산타클로스에게 편지를 보낼 수 없습니다.');
+    }
+
     return this.letterRepository.sendLetter({
       ...sendLetterDto,
-      senderId: userId,
+      senderId,
       status: LetterStatusValue.SENT,
       sentAt: new Date(),
     });

--- a/src/letter/santa-user-id.provider.ts
+++ b/src/letter/santa-user-id.provider.ts
@@ -1,0 +1,34 @@
+import { Provider } from '@nestjs/common';
+import { AuthNativeRepository } from 'src/auth/auth-naitve/auth-native.repository';
+import { SANTA_PROVIDER_ID } from 'src/calendar-reward/calender-reward.constants';
+
+/**
+ * LetterService에 캐시된 산타 ID를 주입하기 위한 고유 키
+ */
+export const SANTA_USER_ID = 'SANTA_USER_ID';
+
+/**
+ * 앱 시작 시 1회만 DB를 조회하여 산타 ID를 캐시/주입하는 커스텀 프로바이더
+ */
+export const SantaUserIdProvider: Provider = {
+  provide: SANTA_USER_ID,
+  useFactory: async (
+    authNativeRepository: AuthNativeRepository,
+  ): Promise<number> => {
+    console.log('[Init] Finding Santa User ID...');
+    // 1. providerId로 산타 유저를 DB에서 찾습니다.
+    const santaUser =
+      await authNativeRepository.findByProviderId(SANTA_PROVIDER_ID);
+
+    if (!santaUser) {
+      throw new Error(
+        'FATAL: Santa User not found in database. Seed data is required.',
+      );
+    }
+
+    console.log(`[Init] Santa User ID Cached: ${santaUser.id}`);
+    // 2. 찾은 id를 반환합니다.
+    return santaUser.id;
+  },
+  inject: [AuthNativeRepository], // useFactory에서 사용할 리포지토리
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

- #69 

## 📝작업 내용

- providerId로 user를 찾는 메서드를 추가
- 앱 최초 실행시 1회만 letter모듈에서 santaId를 찾아 캐시시키는 팩토리함수 실행
산타의 유저의 우편번호(12025)로 편지를 보내지 않게하려면 편지 발송시마다 산타유저에게 보내는지 검사해야 하는데
검사하기 위한 산타유저의 정보를 가져오려면 DB요청이 항상 1번 추가되기 때문에 이를 없애기위해 useFactory 함수를 사용해서
DI 컨테이너 (주입하는 모듈들 정보가 담긴 곳)에 **산타의 정보를 캐시**해놓고 필요할때 가져다 쓰도록 만들었습니다

### 스크린샷 (선택)
<img width="706" height="142" alt="image" src="https://github.com/user-attachments/assets/e4c1f07c-d8bc-4d9b-96ce-60e8146c68a4" />

위 사진 처럼 앱 시작 로그에 Santa 의 Id 값을 캐시했는지 여부가 나옵니다.


## 💬기타 전달사항(선택)
모르고 #71 브랜치에 작업해서 #69 브랜치로 해당 작업 commit 을 옮겨서 push 했습니다.