### PR TITLE
feat/#70/회원가입시 가입 선물 n개 지급하는 기능 추가

### DIFF
--- a/src/auth/auth-naitve/auth-native.service.ts
+++ b/src/auth/auth-naitve/auth-native.service.ts
@@ -18,6 +18,7 @@ import { AuthNativeRepository } from './auth-native.repository';
 import { create6DigitCode } from '../functions/digit-code';
 import { AuthWithdrawDto } from '../dtos/auth-withdraw.dto';
 import { loginTypeValue } from 'src/common/enums/login-type.enum';
+import { CalendarRewardService } from 'src/calendar-reward/calendar-reward.service';
 
 @Injectable()
 export class AuthNativeService {
@@ -26,6 +27,7 @@ export class AuthNativeService {
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
     private readonly emailService: EmailService,
+    private readonly calendarRewardService: CalendarRewardService,
   ) {}
 
   /**
@@ -134,10 +136,22 @@ export class AuthNativeService {
       zipCode: uniqueZipCode,
     });
 
-    // 5. 인증코드를 삭제
+    // 5. 신규 유저에게 과거 선물 일괄 지급
+    try {
+      // 11/12 출시라면, 11/1 ~ 11/11 선물을 1회성 지급
+      await this.calendarRewardService.grantGiftsForNewUser(newUser.id);
+    } catch (e) {
+      // 선물 지급이 실패해도 회원가입은 롤백되지 않음 (에러 로깅만)
+      console.error(
+        `[Non-Fatal] Failed to grant welcome gifts for user ${newUser.id}`,
+        e,
+      );
+    }
+
+    // 6. 사용된 인증코드를 삭제
     await this.authNativeRepository.deleteAuthCodeByEmail(dto.email);
 
-    // 6. 토큰 발급 및 리프레시 토큰 저장
+    // 7. 토큰 발급 및 리프레시 토큰 저장
     return this.getTokens(newUser);
   }
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { UsersModule } from '../users/users.module';
@@ -15,6 +15,7 @@ import { EmailService } from './Email/auth-email.service';
 import { AuthNativeController } from './auth-naitve/auth-native.controller';
 import { AuthNativeService } from './auth-naitve/auth-native.service';
 import { AuthNativeRepository } from './auth-naitve/auth-native.repository';
+import { CalendarRewardModule } from 'src/calendar-reward/calendar-reward.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { AuthNativeRepository } from './auth-naitve/auth-native.repository';
     UsersModule,
     HttpModule,
     FirebaseAdminModule,
+    forwardRef(() => CalendarRewardModule),
   ],
   providers: [
     AuthService,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -13,11 +13,9 @@ type ReqUser = { id: number; uid: string };
 export class AuthService {
   constructor(
     private readonly authRepository: AuthRepository,
-    private readonly jwtService: JwtService,
     private readonly firebaseAdminService: FirebaseAdminService,
     private readonly usersService: UsersService,
     private readonly configService: ConfigService,
-    private readonly emailService: EmailService,
   ) {}
 
   // Kakao Access Token -> Firebase Custom Token 발급

--- a/src/calendar-reward/calendar-reward.module.ts
+++ b/src/calendar-reward/calendar-reward.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { CalendarRewardController } from './calendar-reward.controller';
 import { CalendarRewardService } from './calendar-reward.service';
 import { CalendarRewardRepository } from './calendar-reward.repository';
@@ -6,7 +6,7 @@ import { UsersModule } from 'src/users/users.module';
 import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
-  imports: [UsersModule, AuthModule],
+  imports: [UsersModule, forwardRef(() => AuthModule)],
   controllers: [CalendarRewardController],
   providers: [CalendarRewardService, CalendarRewardRepository],
   exports: [CalendarRewardService],

--- a/src/calendar-reward/calendar-reward.repository.ts
+++ b/src/calendar-reward/calendar-reward.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { SANTA_TRIGGER_GIFT_NAME } from './calender-reward.constants';
 
 @Injectable()
 export class CalendarRewardRepository {
@@ -40,6 +41,65 @@ export class CalendarRewardRepository {
       // 하루 1회: (userId, localDate) PK
       return tx.calendarRewardRecord.create({
         data: { userId, localDate, giftId },
+      });
+    });
+  }
+
+  // 아래는 앱 출시가 늦어지면서 추가된 메서드들입니다.
+
+  /**
+   * 출시 날짜 '이전'까지의 모든 'GIFT' 보상 계획을 조회합니다.
+   * (신규 유저 가입 시 1회성 지급용)
+   */
+  async findHistoricalPlans(startDate: Date, beforeDate: Date) {
+    return this.prisma.calendarRewardPlan.findMany({
+      where: {
+        localDate: {
+          gte: startDate, // 시작 날짜
+          lt: beforeDate, // 끝 날짜보다 작은
+        },
+        gift: {
+          name: {
+            not: SANTA_TRIGGER_GIFT_NAME, // (혹시 모를 산타 편지 트리거 제외)
+          },
+        },
+      },
+      select: {
+        localDate: true,
+        giftId: true,
+      },
+    });
+  }
+
+  /**
+   * 신규 유저에게 여러 개의 선물을 트랜잭션으로 일괄 지급합니다.
+   * (UserGift와 CalendarRewardRecord에 동시 생성)
+   */
+  async bulkGrantGiftsForNewUser(
+    userId: number,
+    gifts: { localDate: Date; giftId: number }[],
+  ) {
+    const now = new Date();
+
+    return this.prisma.$transaction(async (tx) => {
+      // 1. CalendarRewardRecord에 일괄 삽입
+      await tx.calendarRewardRecord.createMany({
+        data: gifts.map((g) => ({
+          userId: userId,
+          localDate: g.localDate,
+          giftId: g.giftId,
+          receivedAt: now,
+        })),
+      });
+
+      // 2. UserGift에 일괄 삽입
+      await tx.userGift.createMany({
+        data: gifts.map((g) => ({
+          userId: userId,
+          giftId: g.giftId,
+          obtainedAt: now,
+        })),
+        skipDuplicates: true, // (혹시 모를 중복 방지)
       });
     });
   }

--- a/src/calendar-reward/calendar-reward.service.ts
+++ b/src/calendar-reward/calendar-reward.service.ts
@@ -9,7 +9,9 @@ import { Prisma } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { LetterStatusValue } from 'src/common/enums/letter-status.enum';
 import {
+  APP_LAUNCH_DATE,
   CHRISTMAS_PAPER_ID,
+  EVENT_START_DATE,
   EVENT_TZ,
   SANTA_LETTER_CONTENT,
   SANTA_PROVIDER_ID,
@@ -117,6 +119,7 @@ export class CalendarRewardService {
     }
   }
 
+  /** 산타편지를 유저에게 전송 */
   private async sendSantaLetterOnce(receiverId: number): Promise<{
     received: boolean;
     letter?: {
@@ -175,6 +178,50 @@ export class CalendarRewardService {
         return { received: false };
       }
       throw e;
+    }
+  }
+
+  /**
+   * 신규 유저 회원가입 시, 기본 선물 일괄 지급 (1회성)
+   * authNative Service에서 호출
+   */
+  async grantGiftsForNewUser(userId: number) {
+    const startDate = this.dateYmdToDateObject(EVENT_START_DATE); // 시작날짜
+    const beforeDate = this.dateYmdToDateObject(APP_LAUNCH_DATE); // 출시날짜
+
+    console.log(startDate, beforeDate);
+
+    // 1. (11/1 ~ 11/11)까지의 모든 'GIFT' 선물 계획 조회
+    const historicalPlans =
+      await this.calendarRewardRepository.findHistoricalPlans(
+        startDate,
+        beforeDate,
+      );
+
+    console.log(historicalPlans);
+    if (historicalPlans.length === 0) {
+      console.log(`No historical gifts to grant for new user ${userId}.`);
+      return;
+    }
+
+    // 2. [트랜잭션] 누락된 선물(N개)을 한꺼번에 지급
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await this.calendarRewardRepository.bulkGrantGiftsForNewUser(
+          userId,
+          historicalPlans,
+        );
+      });
+      console.log(
+        `Successfully granted ${historicalPlans.length} historical gifts to new user ${userId}.`,
+      );
+    } catch (e) {
+      // 중요: 이 로직이 실패해도 회원가입이 롤백되면 안 됨.
+      // 에러를 로깅만 하고, 상위 서비스(AuthService)로 throw하지 않음.
+      console.error(
+        `[CRITICAL] Failed to grant historical gifts for new user ${userId}`,
+        e,
+      );
     }
   }
 

--- a/src/calendar-reward/calendar-reward.service.ts
+++ b/src/calendar-reward/calendar-reward.service.ts
@@ -13,6 +13,7 @@ import {
   CHRISTMAS_PAPER_ID,
   EVENT_START_DATE,
   EVENT_TZ,
+  REWARD_TYPE,
   SANTA_LETTER_CONTENT,
   SANTA_PROVIDER_ID,
   SANTA_TRIGGER_GIFT_NAME,
@@ -59,7 +60,7 @@ export class CalendarRewardService {
         // (성공)
         return {
           received: true,
-          rewardType: 'LETTER',
+          rewardType: REWARD_TYPE.LETTER,
           localDate: todayYmd,
           giftName: plan.gift.name,
           letter: {
@@ -71,7 +72,7 @@ export class CalendarRewardService {
       } else {
         // (이미 받음)
         return {
-          rewardType: 'LETTER',
+          rewardType: REWARD_TYPE.LETTER,
           received: false,
         };
       }
@@ -85,21 +86,21 @@ export class CalendarRewardService {
       );
     if (existing) {
       return {
-        rewardType: 'GIFT',
+        rewardType: REWARD_TYPE.GIFT,
         received: false,
       };
     }
 
     // 생성 시 동시 요청이 있더라도 PK 충돌만 캐치하면 멱등
     try {
-      const claim =
-        await this.calendarRewardRepository.createRecordAndEnsureInventory(
-          userId,
-          todayDate,
-          plan.gift.id,
-        );
+      await this.calendarRewardRepository.createRecordAndEnsureInventory(
+        userId,
+        todayDate,
+        plan.gift.id,
+      );
+
       return {
-        rewardType: 'GIFT',
+        rewardType: REWARD_TYPE.GIFT,
         received: true,
         localDate: todayYmd,
         giftId: plan.gift.id,
@@ -166,7 +167,7 @@ export class CalendarRewardService {
         received: true,
         letter: {
           id: newLetter.id,
-          senderId: santaUser.id, // 👈 [변경] senderId (산타 ID) 반환
+          senderId: santaUser.id, // senderId (산타 ID) 반환
         },
       };
     } catch (e) {

--- a/src/calendar-reward/calendar-reward.service.ts
+++ b/src/calendar-reward/calendar-reward.service.ts
@@ -189,8 +189,6 @@ export class CalendarRewardService {
     const startDate = this.dateYmdToDateObject(EVENT_START_DATE); // 시작날짜
     const beforeDate = this.dateYmdToDateObject(APP_LAUNCH_DATE); // 출시날짜
 
-    console.log(startDate, beforeDate);
-
     // 1. (11/1 ~ 11/11)까지의 모든 'GIFT' 선물 계획 조회
     const historicalPlans =
       await this.calendarRewardRepository.findHistoricalPlans(
@@ -198,7 +196,6 @@ export class CalendarRewardService {
         beforeDate,
       );
 
-    console.log(historicalPlans);
     if (historicalPlans.length === 0) {
       console.log(`No historical gifts to grant for new user ${userId}.`);
       return;
@@ -206,12 +203,11 @@ export class CalendarRewardService {
 
     // 2. [트랜잭션] 누락된 선물(N개)을 한꺼번에 지급
     try {
-      await this.prisma.$transaction(async (tx) => {
-        await this.calendarRewardRepository.bulkGrantGiftsForNewUser(
-          userId,
-          historicalPlans,
-        );
-      });
+      await this.calendarRewardRepository.bulkGrantGiftsForNewUser(
+        userId,
+        historicalPlans,
+      );
+
       console.log(
         `Successfully granted ${historicalPlans.length} historical gifts to new user ${userId}.`,
       );

--- a/src/calendar-reward/calender-reward.constants.ts
+++ b/src/calendar-reward/calender-reward.constants.ts
@@ -38,3 +38,8 @@ export const EVENT_START_DATE = '2025-11-01';
 
 // 2. 앱 출시일 (이 날짜 '전날'까지의 선물을 가입 시 지급) * 추후 변경되는 날짜!
 export const APP_LAUNCH_DATE = '2025-11-12';
+
+export const REWARD_TYPE = {
+  GIFT: 'GIFT',
+  LETTER: 'LETTER',
+} as const;

--- a/src/calendar-reward/calender-reward.constants.ts
+++ b/src/calendar-reward/calender-reward.constants.ts
@@ -32,3 +32,9 @@ export const SANTA_LETTER_CONTENT = `메리 크리스마스!
 
 언제나 너를 응원하는
 산타할아버지가 🎅`;
+
+// 1. 이벤트 시작일 (이 날짜부터 선물을 줌)
+export const EVENT_START_DATE = '2025-11-01';
+
+// 2. 앱 출시일 (이 날짜 '전날'까지의 선물을 가입 시 지급) * 추후 변경되는 날짜!
+export const APP_LAUNCH_DATE = '2025-11-12';

--- a/src/calendar-reward/dtos/res-enter-calendar-reward.dto.ts
+++ b/src/calendar-reward/dtos/res-enter-calendar-reward.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
+import { REWARD_TYPE } from '../calender-reward.constants';
 
 /**
  * 12/25 산타 편지 응답에 포함될 편지 정보 DTO
@@ -13,16 +14,18 @@ class ResEnterCalendarLetterDto {
   senderId: number;
 }
 
+type RewardTypeValues = (typeof REWARD_TYPE)[keyof typeof REWARD_TYPE];
+
 /**
  * 캘린더 진입(POST /calendar/enter) 응답 DTO
  */
 export class ResEnterCalendarDto {
   @ApiProperty({
-    example: 'GIFT',
-    enum: ['GIFT', 'LETTER'],
+    example: REWARD_TYPE.GIFT,
+    enum: REWARD_TYPE,
     description: '오늘 보상 타입 (GIFT: 일반 아이템, LETTER: 산타 편지)',
   })
-  rewardType: 'GIFT' | 'LETTER';
+  rewardType: RewardTypeValues;
 
   @ApiProperty({
     example: true,


### PR DESCRIPTION
## #️⃣연관된 이슈

- #70 

## 📝작업 내용

- 회원가입시 출시일 이전의 선물들을 가입선물로 지급합니다.
ex) 11월 12일에 출시하고 14일에 유저가 가입한다면 11일까지의 선물을 지급 (11개)
캘린더에 유저가 들어가면 14일의 선물을 지급 -> 총 12개의 선물을 가지게 됨.

### 스크린샷 (선택)

## 💬기타사항
- 앱 출시일이 대략적으로 확정되면 날짜 수정 후 merge 하겠습니다
