### PR TITLE
새로 받은 선물에 new! 배지 표시

### DIFF
--- a/prisma/migrations/20251107162311_add_user_last_gift_viewed_at/migration.sql
+++ b/prisma/migrations/20251107162311_add_user_last_gift_viewed_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "last_gift_viewed_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,17 +51,18 @@ enum LoginType {
 }
 
 model User {
-  id             Int       @id @default(autoincrement())
-  email          String?   @unique // (10.13 자체로그인시에만 저장)
-  hashedPassword String?   @map("hashed_password") // 자체로그인시 저장
-  nickname       String    @unique
-  zipCode        Int       @unique @map("zip_code")
-  loginType      LoginType @default(NATIVE) @map("login_type")
-  providerId     String?   @unique @map("provider_id") // 소셜로그인시 저장
-  isAdmin        Boolean   @default(false) @map("is_admin")
-  isAgreed       Boolean   @default(false) @map("is_agreed")
-  createdAt      DateTime  @default(now()) @map("created_at")
-  updatedAt      DateTime  @updatedAt @map("updated_at")
+  id               Int       @id @default(autoincrement())
+  email            String?   @unique // (10.13 자체로그인시에만 저장)
+  hashedPassword   String?   @map("hashed_password") // 자체로그인시 저장
+  nickname         String    @unique
+  zipCode          Int       @unique @map("zip_code")
+  loginType        LoginType @default(NATIVE) @map("login_type")
+  providerId       String?   @unique @map("provider_id") // 소셜로그인시 저장
+  isAdmin          Boolean   @default(false) @map("is_admin")
+  isAgreed         Boolean   @default(false) @map("is_agreed")
+  lastGiftViewedAt DateTime? @map("last_gift_viewed_at")
+  createdAt        DateTime  @default(now()) @map("created_at")
+  updatedAt        DateTime  @updatedAt @map("updated_at")
 
   refreshToken          RefreshToken?
   sentLetters           Letter[]               @relation("SentLetters")

--- a/src/auth/auth-naitve/auth-native.swagger.ts
+++ b/src/auth/auth-naitve/auth-native.swagger.ts
@@ -109,12 +109,12 @@ export const ApiAuthNative = {
     ),
 
   /**
-   * @summary [네이티브] 이메일 중복 확인
+   * @summary [네이티브] 회원가입시 이메일 중복 확인
    */
   checkEmail: () =>
     applyDecorators(
       ApiOperation({
-        summary: '[네이티브] 이메일 중복 확인',
+        summary: '[네이티브] 회원가입시 이메일 중복 확인',
         description:
           '입력한 이메일이 이미 데이터베이스에 등록되어 있는지 확인합니다.',
       }),
@@ -137,12 +137,12 @@ export const ApiAuthNative = {
     ),
 
   /**
-   * @summary [네이티브] 닉네임 중복 확인
+   * @summary [네이티브] 회원가입시 닉네임 중복 확인
    */
   checkNickname: () =>
     applyDecorators(
       ApiOperation({
-        summary: '[공통] 닉네임 중복 확인',
+        summary: '[공통] 회원가입시 닉네임 중복 확인',
         description:
           '입력한 닉네임이 이미 데이터베이스에 등록되어 있는지 확인합니다.',
       }),

--- a/src/calendar-reward/calendar-reward.swagger.ts
+++ b/src/calendar-reward/calendar-reward.swagger.ts
@@ -12,7 +12,7 @@ export const ApiCalendarReward = {
   enter: () =>
     applyDecorators(
       ApiOperation({
-        summary: '[캘린더] 오늘의 선물 받기 (매일 1회)',
+        summary: '오늘의 선물 받기 (매일 1회)',
         description: `캘린더 화면 진입 시 호출합니다.
 - 오늘 날짜의 선물을 지급합니다 (멱등성 보장).
 - 11/1~12/24: 일반 아이템 지급 (GIFT)
@@ -68,7 +68,7 @@ export const ApiCalendarReward = {
   sendTestSanta: () =>
     applyDecorators(
       ApiOperation({
-        summary: '[테스트용] 산타 편지 즉시 받기 🎅',
+        summary: '산타 편지 즉시 받기 (개발용/관리자용)',
         description:
           '12월 25일을 기다리지 않고 산타 편지를 즉시 받습니다. (1회만 가능)',
       }),

--- a/src/gift/dtos/res-my-gift.dto.ts
+++ b/src/gift/dtos/res-my-gift.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  GiftCategory,
+  GiftCategoryValue,
+} from 'src/common/enums/gift-category.enum';
+
+export class ResMyGiftDto {
+  @ApiProperty({ example: 1 })
+  giftId: number;
+
+  @ApiProperty({ example: '진저 쿠키' })
+  name: string;
+
+  @ApiProperty({ enum: GiftCategoryValue, example: 'ORNAMENT' })
+  category: GiftCategory;
+
+  @ApiProperty({ example: 'true' })
+  isNew: boolean;
+}

--- a/src/gift/gift.controller.ts
+++ b/src/gift/gift.controller.ts
@@ -39,7 +39,7 @@ export class GiftController {
   }
 
   // 선물함 확인했음용 API (=NEW 뱃지 제거용)
-  @Post('viewes')
+  @Post('checked-view')
   @HttpCode(200)
   @ApiGifts.updateLastGiftViewed()
   async updateLastGiftViewed(

--- a/src/gift/gift.controller.ts
+++ b/src/gift/gift.controller.ts
@@ -22,6 +22,7 @@ import { UpdateEquippedDto } from './dtos/update-equipped.dto';
 import { CreateGiftDto } from './dtos/dev-add-my-gift.dto';
 import { ResEquippedGiftDto } from './dtos/res-equipped-gift.dto';
 import { ResGiftDto } from './dtos/res-gift.dto';
+import { ResMyGiftDto } from './dtos/res-my-gift.dto';
 
 /** 추후 관리자 토큰 가드 추가 예정 */
 @ApiTags('gift')
@@ -33,8 +34,18 @@ export class GiftController {
   // 나의 gifts 조회 (필요없는 값은 수정해서 성능 향상해야됨 10.03)
   @Get('me')
   @ApiGifts.findMine()
-  async getMyGifts(@GetUserId() userId: number) {
-    return this.giftService.findUserGifts(userId);
+  async getMyGifts(@GetUserId() userId: number): Promise<ResMyGiftDto[]> {
+    return this.giftService.findMyGifts(userId);
+  }
+
+  // 선물함 확인했음용 API (=NEW 뱃지 제거용)
+  @Post('viewes')
+  @HttpCode(200)
+  @ApiGifts.updateLastGiftViewed()
+  async updateLastGiftViewed(
+    @GetUserId() userId: number,
+  ): Promise<{ success: boolean }> {
+    return this.giftService.updateLastGiftViewed(userId);
   }
 
   // 장착된 선물들 조회

--- a/src/gift/gift.repository.ts
+++ b/src/gift/gift.repository.ts
@@ -12,10 +12,15 @@ export class GiftRepository {
   /**
    * 나의 gifts 조회
    */
-  async findUserGifts(userId: number) {
+  async findMyGifts(userId: number) {
     const myGifts = this.prisma.userGift.findMany({
       where: { userId },
-      select: { gift: { select: { id: true, name: true, category: true } } },
+      select: {
+        gift: {
+          select: { id: true, name: true, category: true },
+        },
+        obtainedAt: true,
+      },
     });
     return myGifts;
   }

--- a/src/gift/gift.service.ts
+++ b/src/gift/gift.service.ts
@@ -11,22 +11,33 @@ import {
 import { UpdateEquippedDto } from './dtos/update-equipped.dto';
 import { ResEquippedGiftDto } from './dtos/res-equipped-gift.dto';
 import { ResGiftDto } from './dtos/res-gift.dto';
+import { UsersRepository } from 'src/users/users.repository';
+import { ResMyGiftDto } from './dtos/res-my-gift.dto';
 
 @Injectable()
 export class GiftService {
-  constructor(private readonly giftRepository: GiftRepository) {}
+  constructor(
+    private readonly giftRepository: GiftRepository,
+    private readonly usersRepository: UsersRepository,
+  ) {}
 
-  async findUserGifts(userId: number) {
-    const myGifts = await this.giftRepository.findUserGifts(userId);
+  async findMyGifts(userId: number): Promise<ResMyGiftDto[]> {
+    // 선물함 들어간 마지막 시간을 가져옴.
+    const user = await this.usersRepository.findUserForNewGiftCheck(userId);
 
-    // 1. GIFT로 매핑합니다.
+    const lastViewed = user.lastGiftViewedAt || new Date(0); // =1970년 1월 1일
+
+    const myGifts = await this.giftRepository.findMyGifts(userId);
+
+    // 1. GIFT로 매핑.
     const gifts = myGifts.map((userGift) => ({
       giftId: userGift.gift.id,
       name: userGift.gift.name,
       category: userGift.gift.category, // 이 카테고리 기준
+      isNew: userGift.obtainedAt > lastViewed,
     }));
 
-    // 2. GIFT 배열을 'categoryRankMap' 기준으로 정렬합니다.
+    // 2. GIFT 배열을 'categoryRankMap' 기준으로 정렬.
     gifts.sort((a, b) => {
       const rankA = categoryRankMap.get(a.category) ?? 99; // ?? 99 는 정렬 예외처리
       const rankB = categoryRankMap.get(b.category) ?? 99;
@@ -35,6 +46,12 @@ export class GiftService {
 
     // 3. 정렬된 GIFT 배열을 반환합니다.
     return gifts;
+  }
+
+  async updateLastGiftViewed(userId: number): Promise<{ success: boolean }> {
+    // (UserRepository에 updateLastGiftViewed 메서드가 필요합니다)
+    await this.usersRepository.updateLastGiftViewed(userId, new Date());
+    return { success: true };
   }
 
   async getEquippedGifts(userId: number): Promise<ResEquippedGiftDto[]> {

--- a/src/gift/gift.swagger.ts
+++ b/src/gift/gift.swagger.ts
@@ -1,10 +1,17 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { GiftCategoryValue } from 'src/common/enums/gift-category.enum';
 import { ResGiftDto } from './dtos/res-gift.dto';
 import { UpdateEquippedDto } from './dtos/update-equipped.dto';
 import { CreateGiftDto } from './dtos/dev-add-my-gift.dto';
 import { ResEquippedGiftDto } from './dtos/res-equipped-gift.dto';
+import { ResMyGiftDto } from './dtos/res-my-gift.dto';
 
 export const ApiGifts = {
   findMine: () =>
@@ -12,8 +19,34 @@ export const ApiGifts = {
       ApiOperation({ summary: '내가 가진 gifts 조회' }),
       ApiResponse({
         status: 200,
-        type: [ResGiftDto],
+        type: [ResMyGiftDto],
         description: '현재 로그인한 사용자가 보유한 gift 목록',
+      }),
+      ApiBearerAuth('accessToken'),
+    ),
+
+  updateLastGiftViewed: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '선물함 "NEW" 배지 제거 (확인 처리)',
+        description: `선물함을 확인했음을 서버에 알려 User의 'lastGiftViewedAt'을 갱신합니다.
+이 API 호출 이후 '내가 가진 gifts 조회' API를 호출하면, 갱신된 시간을 기준으로 'isNew'가 계산됩니다.`,
+      }),
+      ApiBearerAuth('accessToken'), // 👈 AuthGuard('accessToken')가 있으므로 명시
+
+      ApiResponse({
+        status: 200,
+        description: '선물함 확인 시간 갱신 성공',
+        schema: {
+          example: { success: true },
+        },
+      }),
+      ApiResponse({
+        status: 401,
+        description: '인증 실패 (Unauthorized)',
+        schema: {
+          example: { message: 'Unauthorized', statusCode: 401 },
+        },
       }),
     ),
 
@@ -25,6 +58,7 @@ export const ApiGifts = {
         type: [ResEquippedGiftDto],
         description: '현재 로그인한 사용자가 장착한 gift 목록',
       }),
+      ApiBearerAuth('accessToken'),
     ),
 
   updateEquipped: () =>
@@ -36,7 +70,9 @@ export const ApiGifts = {
         type: [ResEquippedGiftDto],
         description: '성공적으로 업데이트된 후의 최종 장착 목록',
       }),
+      ApiBearerAuth('accessToken'),
     ),
+
   findAll: () =>
     applyDecorators(
       ApiOperation({ summary: '전체 gift 조회 (개발용/관리자용)' }),

--- a/src/music/music.controller.ts
+++ b/src/music/music.controller.ts
@@ -9,7 +9,7 @@ import {
   ParseIntPipe,
   HttpCode,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiExcludeController, ApiTags } from '@nestjs/swagger';
 import { MusicService } from './music.service';
 import { CreateMusicDto } from './dtos/create-music.dto';
 import { UpdateMusicDto } from './dtos/update-music.dto';
@@ -18,6 +18,7 @@ import { ApiMusics } from './music.swagger';
 
 @Controller('musics')
 @ApiTags('musics')
+@ApiExcludeController() // 음악을 앱 자체저장하는 방식으로 바꾸면서 스웨거에서 숨깁니다.
 // @UseGuards(FirebaseAuthGuard) // 여기는 admin 가드로 추후 변경 (09.16)
 export class MusicController {
   constructor(private readonly musicService: MusicService) {}

--- a/src/schedule/schedule.swagger.ts
+++ b/src/schedule/schedule.swagger.ts
@@ -1,5 +1,11 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiQuery, ApiResponse, ApiBody } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiBody,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { MonthlyScheduleResDto } from './dtos/monthly-schedule-res.dto';
 import { DailyScheduleResDto } from './dtos/daily-schedule-res.dto';
 import { CreateScheduleDto } from './dtos/create-schedule.dto';
@@ -8,6 +14,7 @@ import { UpdateScheduleDto } from './dtos/update-schedule.dto';
 export const ApiSchedules = {
   getMonthly: () =>
     applyDecorators(
+      ApiBearerAuth('accessToken'),
       ApiOperation({
         summary: '월별 일정 조회',
         description: '해당 연도/월의 일정들을 조회합니다.',
@@ -24,6 +31,7 @@ export const ApiSchedules = {
 
   getDaily: () =>
     applyDecorators(
+      ApiBearerAuth('accessToken'),
       ApiOperation({
         summary: '일별 일정 조회',
         description: '해당 일자의 전체 일정 정보를 조회합니다.',
@@ -39,6 +47,7 @@ export const ApiSchedules = {
 
   create: () =>
     applyDecorators(
+      ApiBearerAuth('accessToken'),
       ApiOperation({
         summary: '일정 추가',
         description: '새 일정을 추가합니다.',
@@ -53,6 +62,7 @@ export const ApiSchedules = {
 
   update: () =>
     applyDecorators(
+      ApiBearerAuth('accessToken'),
       ApiOperation({
         summary: '일정 수정',
         description: '기존 일정을 수정합니다.',
@@ -71,6 +81,7 @@ export const ApiSchedules = {
 
   delete: () =>
     applyDecorators(
+      ApiBearerAuth('accessToken'),
       ApiOperation({ summary: '일정 삭제', description: '일정을 삭제합니다.' }),
       ApiResponse({
         status: 204,

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { FoundUserDto } from './dtos/res-user.dto';
+import { User } from '@prisma/client';
 
 @Injectable()
 export class UsersRepository {
@@ -32,6 +33,26 @@ export class UsersRepository {
         providerId: true,
         isAdmin: true,
       },
+    });
+  }
+
+  // new 아이템 조회할때 사용
+  async findUserForNewGiftCheck(
+    userId: number,
+  ): Promise<{ lastGiftViewedAt: Date | null } | null> {
+    return this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        lastGiftViewedAt: true,
+      },
+    });
+  }
+
+  // 나의 아이템 조회 후 사용
+  async updateLastGiftViewed(userId: number, time: Date): Promise<User> {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: { lastGiftViewedAt: time },
     });
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #75 

## 📝작업 내용

- 연관 이슈 들어가서서 보시면 작업 내용 볼 수 있습니다!

### 스크린샷 (선택)
<img width="1347" height="371" alt="image" src="https://github.com/user-attachments/assets/aad0ab4d-7e84-42ca-9cde-1472cd6e7922" />

파란 체크표시 API를 수정, 추가 했습니다.
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/aa240211-1ec3-4a3b-b6d8-ba96da4bb7dd" />
- 기존 내가 가진 gift 조회 API는 위 사진 처럼 새롭게 받은 선물이라면 isNew: true 값이, 아니라면 false가 담겨서 반환되도록 수정했습니다.
- isNew 값의 상태를 최신화 하기 위해서 선물함에 들어가서 선물 데이터를 받음과 동시에 `/gifts/views` 를 호출하여 마지막으로 선물함을 본 시간을 현재 시간으로 기록합니다.

따라서 선물을 받은 후 (몇 개든지) 최초로 선물함에 들어간다면 이전에 확인하지 않았던 선물은 isNew: true 값을 반환합니다.

## 💬리뷰 요구사항(선택)
`/gifts/views` API 의 엔드포인트 네이밍이 딱 생각나는게 없네요.. 괜찮나요? 적절한게 있으면 추천부탁드립니다. 뭔가 맘에 안들어서요
해당 api의 메서드는 patch로 하려다가 수정하는 동작이라기보다 현재 선물함에 들어간 동작을 기록 하는 느낌이라 post로 했습니다