### PR TITLE
Modify/#77/modify letter domain

### DIFF
--- a/src/letter/dtos/res-sent-letter.dto.ts
+++ b/src/letter/dtos/res-sent-letter.dto.ts
@@ -16,7 +16,7 @@ export class ResSentLetterDto {
   @ApiProperty({
     example: LetterStatusValue.SENT,
     enum: LetterStatusValue,
-    description: '편지 상태 (무조건 SENT)',
+    description: '편지 상태 (SENT or RECEIVED',
   })
   status: LetterStatus;
 

--- a/src/letter/letter.controller.ts
+++ b/src/letter/letter.controller.ts
@@ -53,7 +53,7 @@ export class LetterController {
     return await this.letterService.saveWriting(userId, saveWritingDto);
   }
 
-  /** 내 사서함 조회 */
+  /** 내 사서함 (받은 편지)조회 */
   @Get('received')
   @ApiLetters.findReceived()
   async findReceivedLetters(

--- a/src/letter/letter.repository.ts
+++ b/src/letter/letter.repository.ts
@@ -167,6 +167,7 @@ export class LetterRepository {
       where: {
         id: { in: letterIds },
         senderId: userId,
+        status: LetterStatusValue.WRITING, // 작성중인 편지만 삭제 가능
       },
       select: { id: true, imageUrl: true, status: true, paperId: true },
     });

--- a/src/letter/letter.repository.ts
+++ b/src/letter/letter.repository.ts
@@ -190,6 +190,26 @@ export class LetterRepository {
     });
   }
 
+  /**
+   * letterId + userId(본인)로 편지 조회
+   * (본인이 senderId 또는 receiverId와 일치해야만 조회됨)
+   */
+  findLetterByIdAndUser(
+    letterId: number,
+    userId: number,
+  ): Promise<LetterDetail | null> {
+    return this.prisma.letter.findFirst({
+      where: {
+        id: letterId,
+        OR: [
+          { senderId: userId }, // 내가 보냈거나
+          { receiverId: userId }, // 내가 받음
+        ],
+      },
+      select: letterSelect, // 공통 select 적용
+    });
+  }
+
   /** 편지 상태 변경 */
   async updateLetterStatus(
     letterId: number,

--- a/src/letter/letter.repository.ts
+++ b/src/letter/letter.repository.ts
@@ -122,11 +122,9 @@ export class LetterRepository {
     return this.prisma.letter.findMany({
       where: {
         senderId: userId,
-        status: LetterStatusValue.SENT,
+        status: { in: [LetterStatusValue.SENT, LetterStatusValue.RECEIVED] },
       },
-      orderBy: {
-        sentAt: 'desc',
-      },
+      orderBy: [{ status: 'desc' }, { sentAt: 'desc' }],
       select: {
         id: true,
         status: true,
@@ -168,7 +166,7 @@ export class LetterRepository {
     return this.prisma.letter.findMany({
       where: {
         id: { in: letterIds },
-        senderId: userId, // 또는 senderId
+        senderId: userId,
       },
       select: { id: true, imageUrl: true, status: true, paperId: true },
     });

--- a/src/letter/letter.repository.ts
+++ b/src/letter/letter.repository.ts
@@ -97,15 +97,19 @@ export class LetterRepository {
     });
   }
 
-  /** 내 사서함 조회 */
+  /** 내 사서함 (받은 편지)조회 */
   async findReceivedLetters(userId: number): Promise<ResReceivedLetterDto[]> {
     return this.prisma.letter.findMany({
       where: {
         receiverId: userId,
+        status: {
+          in: [LetterStatusValue.SENT, LetterStatusValue.RECEIVED],
+        },
       },
-      orderBy: {
-        sentAt: 'desc',
-      },
+      orderBy: [
+        { status: 'desc' }, // 'SENT'(안 읽음)가 'RECEIVED'(읽음)보다 먼저 오도록
+        { sentAt: 'desc' }, // 그 다음 최신순 정렬
+      ],
       select: {
         id: true,
         status: true,

--- a/src/letter/letter.service.ts
+++ b/src/letter/letter.service.ts
@@ -56,7 +56,10 @@ export class LetterService {
   /** 단일 조회 */
   async findLetter(letterId: number, userId: number): Promise<ResLetterDto> {
     // 일단 편지 데이터를 조회
-    const letter = await this.letterRepository.findLetterById(letterId);
+    const letter = await this.letterRepository.findLetterByIdAndUser(
+      letterId,
+      userId,
+    );
     if (!letter) throw new NotFoundException('Letter not found');
 
     let letterData = letter;

--- a/src/letter/letter.service.ts
+++ b/src/letter/letter.service.ts
@@ -116,37 +116,25 @@ export class LetterService {
 
   /** 삭제 */
   async deleteLetters(letterIds: number[], userId: number) {
-    // 1. 유효한 편지 조회 (user 소유)
-    const existingLetters = await this.letterRepository.findUserLettersByIds(
+    // 1. 유효한 편지 조회 (user 소유 & WRITING 상태)
+    const deletableLetters = await this.letterRepository.findUserLettersByIds(
       letterIds,
       userId,
     );
 
-    // 1-1. 사용자가 요청한 ID 중, 소유권이 확인된 편지가 하나도 없다면
-    if (existingLetters.length === 0) {
-      throw new NotFoundException('삭제할 편지를 찾을 수 없습니다.');
-    }
-
-    // 2. [핵심] 소유권이 확인된 편지 중 "WRITING" 상태인 편지만 필터링
-    const deletableLetters = existingLetters.filter(
-      (letter) => letter.status === LetterStatusValue.WRITING,
-    );
-
-    // 2-1. 삭제 가능한 편지의 ID 목록 추출
+    // 1-1. 삭제 가능한 편지의 ID 목록 추출
     const deletableIds = deletableLetters.map((letter) => letter.id);
 
-    // 2-2. 소유권은 있으나 WRITING 상태가 아니거나,
+    // 1-2. 소유권은 있으나 WRITING 상태가 아니거나,
     //      애초에 소유권이 없는 ID 목록
     const invalidIds = letterIds.filter((id) => !deletableIds.includes(id));
 
-    // 2-3. 실제로 삭제할 편지가 하나도 없다면 (ex: SENT 상태의 편지만 요청 시)
+    // 2. 사용자가 요청한 편지 ID 중, 소유권이 확인된 편지가 하나도 없다면
     if (deletableIds.length === 0) {
-      throw new BadRequestException(
-        '삭제 가능한 편지가 없습니다. (WRITING 상태의 편지만 삭제 가능)',
-      );
+      throw new NotFoundException('삭제 가능한 편지가 없습니다.');
     }
 
-    // 3-1. s3 이미지 keys 추출 (삭제할 편지들만)
+    // 3. s3 이미지 keys 추출 및 삭제 (삭제할 편지들만)
     const s3Keys = deletableLetters
       .map((letter) => letter.imageUrl)
       .filter((key) => !!key); // map을 돌린 후 null 값은 제거
@@ -155,7 +143,7 @@ export class LetterService {
       await this.s3Service.deleteObjects(s3Keys);
     }
 
-    // 2-2. DB에서 실제 삭제
+    // 4. DB에서 삭제
     const result = await this.letterRepository.deleteLetters(deletableIds);
 
     return {

--- a/src/letter/letter.service.ts
+++ b/src/letter/letter.service.ts
@@ -89,7 +89,7 @@ export class LetterService {
     return { ...restOfLetterData, presignedUrl };
   }
 
-  /** 내 사서함 확인 */
+  /** 내 사서함 (받은 편지)확인 */
   async findReceivedLetters(userId: number): Promise<ResReceivedLetterDto[]> {
     return this.letterRepository.findReceivedLetters(userId);
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #77

## 📝작업 내용

- 922cdcaa4cf5e894779b40e1ffbb582cfdbdf0b9 보낸 편지함 조회시 sent 상태와 received 상태 편지도 조회되도록 수정 
- e03074a54282a85323306ef9aec0d512d11596fb 편지 삭제 API 리팩토링
- 335febdfb917490f76a31ad355a93c4870fc76b8 단일 편지 조회시 내 소유의 편지인지 확인
- eb45c08a5615dbdd0487f17be87120ed3fb9ff66 내 사서함 조회시 안 읽은 편지와 읽은 편지를 정렬해서 조회

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
