### PR TITLE
feat/#83/신고 기능 생성

### DIFF
--- a/prisma/migrations/20251126055427_create_report_and_ban_table/migration.sql
+++ b/prisma/migrations/20251126055427_create_report_and_ban_table/migration.sql
@@ -1,0 +1,59 @@
+-- CreateEnum
+CREATE TYPE "ReportReason" AS ENUM ('IMPERSONATION_FRAUD', 'SEXUAL_CONTENT', 'SPAM_AND_PHISHING', 'ABUSIVE_LANGUAGE', 'COMMERCIAL_AD', 'POLITICAL_PROPAGANDA');
+
+-- CreateTable
+CREATE TABLE "reports" (
+    "id" SERIAL NOT NULL,
+    "reporter_id" INTEGER NOT NULL,
+    "reported_user_id" INTEGER NOT NULL,
+    "letter_id" INTEGER,
+    "reason" "ReportReason" NOT NULL,
+    "is_resolved" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "reports_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "blocks" (
+    "id" SERIAL NOT NULL,
+    "blocker_id" INTEGER NOT NULL,
+    "blocked_id" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "blocks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "bans" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "reason" TEXT NOT NULL,
+    "banned_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "bans_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "blocks_blocker_id_blocked_id_key" ON "blocks"("blocker_id", "blocked_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "bans_user_id_key" ON "bans"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "reports" ADD CONSTRAINT "reports_reporter_id_fkey" FOREIGN KEY ("reporter_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "reports" ADD CONSTRAINT "reports_reported_user_id_fkey" FOREIGN KEY ("reported_user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "reports" ADD CONSTRAINT "reports_letter_id_fkey" FOREIGN KEY ("letter_id") REFERENCES "letters"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "blocks" ADD CONSTRAINT "blocks_blocker_id_fkey" FOREIGN KEY ("blocker_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "blocks" ADD CONSTRAINT "blocks_blocked_id_fkey" FOREIGN KEY ("blocked_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bans" ADD CONSTRAINT "bans_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20251202145446_create_report_and_ban_table/migration.sql
+++ b/prisma/migrations/20251202145446_create_report_and_ban_table/migration.sql
@@ -35,6 +35,9 @@ CREATE TABLE "bans" (
 );
 
 -- CreateIndex
+CREATE UNIQUE INDEX "reports_reporter_id_letter_id_key" ON "reports"("reporter_id", "letter_id");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "blocks_blocker_id_blocked_id_key" ON "blocks"("blocker_id", "blocked_id");
 
 -- CreateIndex

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,15 @@ enum LoginType {
   SOCIAL // 소셜 로그인 (Firebase)
 }
 
+enum ReportReason {
+  IMPERSONATION_FRAUD // 유출/사칭/사기
+  SEXUAL_CONTENT // 음란물/불건전한 대화
+  SPAM_AND_PHISHING // 낚시/놀람/도배
+  ABUSIVE_LANGUAGE // 욕설/비하
+  COMMERCIAL_AD // 상업적 광고 및 판매
+  POLITICAL_PROPAGANDA // 정당/정치인 비하 및 선거운동
+}
+
 model User {
   id               Int       @id @default(autoincrement())
   email            String?   @unique // (10.13 자체로그인시에만 저장)
@@ -61,6 +70,7 @@ model User {
   isAdmin          Boolean   @default(false) @map("is_admin")
   isAgreed         Boolean   @default(false) @map("is_agreed")
   lastGiftViewedAt DateTime? @map("last_gift_viewed_at")
+  banInfo          Ban?
   createdAt        DateTime  @default(now()) @map("created_at")
   updatedAt        DateTime  @updatedAt @map("updated_at")
 
@@ -76,6 +86,11 @@ model User {
   userGifts             UserGift[]
   userEquipSlots        UserEquipSlot[]
   calendarRewardRecords CalendarRewardRecord[]
+  //신고 관계
+  reportsSent           Report[]               @relation("Reporter")
+  reportsReceived       Report[]               @relation("ReportedUser")
+  blocksSent            Block[]                @relation("Blocker")
+  blocksReceived        Block[]                @relation("Blocked")
 
   @@map("users")
 }
@@ -122,6 +137,7 @@ model Letter {
   sender   User        @relation("SentLetters", fields: [senderId], references: [id], onDelete: Cascade)
   receiver User?       @relation("ReceivedLetters", fields: [receiverId], references: [id], onDelete: SetNull)
   paper    LetterPaper @relation(fields: [paperId], references: [id], onDelete: Restrict)
+  reports  Report[]
 
   @@map("letters")
 }
@@ -359,4 +375,43 @@ model CalendarRewardRecord {
   @@id([userId, localDate])
   @@index([giftId])
   @@map("calendar_reward_records")
+}
+
+// 신고 접수 내역
+model Report {
+  id             Int          @id @default(autoincrement())
+  reporterId     Int
+  reportedUserId Int
+  letterId       Int? // 편지 없이 신고할 수 도 있으므로 일단 optional 처리
+  reason         ReportReason
+  isResolved     Boolean      @default(false) // 관리자 처리 여부
+
+  createdAt DateTime @default(now())
+
+  reporter     User    @relation("Reporter", fields: [reporterId], references: [id], onDelete: Cascade)
+  reportedUser User    @relation("ReportedUser", fields: [reportedUserId], references: [id], onDelete: Cascade)
+  letter       Letter? @relation(fields: [letterId], references: [id], onDelete: SetNull) // 편지가 삭제되어도 신고 기록은 남겨야 함
+}
+
+// 차단 리스트 (상호 차단용)
+model Block {
+  id        Int      @id @default(autoincrement())
+  blockerId Int
+  blockedId Int
+  createdAt DateTime @default(now())
+
+  blocker User @relation("Blocker", fields: [blockerId], references: [id], onDelete: Cascade)
+  blocked User @relation("Blocked", fields: [blockedId], references: [id], onDelete: Cascade)
+
+  @@unique([blockerId, blockedId]) // 중복 차단 방지
+}
+
+// 유저 밴 (영구 정지)
+model Ban {
+  id       Int      @id @default(autoincrement())
+  userId   Int      @unique // 유저당 하나의 밴 기록
+  reason   String   @db.Text // 관리자가 작성하는 구체적 사유
+  bannedAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -392,6 +392,7 @@ model Report {
   reportedUser User    @relation("ReportedUser", fields: [reportedUserId], references: [id], onDelete: Cascade)
   letter       Letter? @relation(fields: [letterId], references: [id], onDelete: SetNull) // 편지가 삭제되어도 신고 기록은 남겨야 함
 
+  @@unique([reporterId, letterId])
   @@map("reports")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -380,38 +380,43 @@ model CalendarRewardRecord {
 // 신고 접수 내역
 model Report {
   id             Int          @id @default(autoincrement())
-  reporterId     Int
-  reportedUserId Int
-  letterId       Int? // 편지 없이 신고할 수 도 있으므로 일단 optional 처리
+  reporterId     Int          @map("reporter_id")
+  reportedUserId Int          @map("reported_user_id")
+  letterId       Int?         @map("letter_id") // 편지 없이 신고할 수 도 있으므로 일단 optional 처리
   reason         ReportReason
-  isResolved     Boolean      @default(false) // 관리자 처리 여부
+  isResolved     Boolean      @default(false) @map("is_resolved") // 관리자 처리 여부
 
-  createdAt DateTime @default(now())
+  createdAt DateTime @default(now()) @map("created_at")
 
   reporter     User    @relation("Reporter", fields: [reporterId], references: [id], onDelete: Cascade)
   reportedUser User    @relation("ReportedUser", fields: [reportedUserId], references: [id], onDelete: Cascade)
   letter       Letter? @relation(fields: [letterId], references: [id], onDelete: SetNull) // 편지가 삭제되어도 신고 기록은 남겨야 함
+
+  @@map("reports")
 }
 
 // 차단 리스트 (상호 차단용)
 model Block {
   id        Int      @id @default(autoincrement())
-  blockerId Int
-  blockedId Int
-  createdAt DateTime @default(now())
+  blockerId Int      @map("blocker_id")
+  blockedId Int      @map("blocked_id")
+  createdAt DateTime @default(now()) @map("created_at")
 
   blocker User @relation("Blocker", fields: [blockerId], references: [id], onDelete: Cascade)
   blocked User @relation("Blocked", fields: [blockedId], references: [id], onDelete: Cascade)
 
   @@unique([blockerId, blockedId]) // 중복 차단 방지
+  @@map("blocks")
 }
 
 // 유저 밴 (영구 정지)
 model Ban {
   id       Int      @id @default(autoincrement())
-  userId   Int      @unique // 유저당 하나의 밴 기록
+  userId   Int      @unique @map("user_id") // 유저당 하나의 밴 기록
   reason   String   @db.Text // 관리자가 작성하는 구체적 사유
-  bannedAt DateTime @default(now())
+  bannedAt DateTime @default(now()) @map("banned_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("bans")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { ImagePresignModule } from './image/image-presign.module';
 import { MusicModule } from './music/music.module';
 import { CalendarRewardModule } from './calendar-reward/calendar-reward.module';
+import { ReportModule } from './report/report.module';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { CalendarRewardModule } from './calendar-reward/calendar-reward.module';
     ImagePresignModule,
     MusicModule,
     CalendarRewardModule,
+    ReportModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/auth-naitve/auth-native.service.ts
+++ b/src/auth/auth-naitve/auth-native.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   Injectable,
   InternalServerErrorException,
   NotFoundException,
@@ -18,6 +19,7 @@ import { AuthNativeRepository } from './auth-native.repository';
 import { create6DigitCode } from '../functions/digit-code';
 import { AuthWithdrawDto } from '../dtos/auth-withdraw.dto';
 import { loginTypeValue } from 'src/common/enums/login-type.enum';
+import { ReportRepository } from 'src/report/report.repository';
 
 @Injectable()
 export class AuthNativeService {
@@ -26,6 +28,7 @@ export class AuthNativeService {
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
     private readonly emailService: EmailService,
+    private readonly reportRepository: ReportRepository,
   ) {}
 
   /**
@@ -163,12 +166,21 @@ export class AuthNativeService {
   // 로그인
   async login(dto: AuthLoginDto): Promise<TokenResponseDto> {
     // 1. 이메일로 사용자 찾기
+
     const user = await this.authNativeRepository.findByEmail(dto.email);
 
     // 사용자가 없거나 (NATIVE가 아닌 다른 타입일 수 있음), 비밀번호가 없으면 에러
     if (!user || user.loginType !== 'NATIVE' || !user.hashedPassword) {
       throw new UnauthorizedException(
         '유효하지 않은 이메일 또는 비밀번호입니다.',
+      );
+    }
+
+    const banInfo = await this.reportRepository.findBanByUserId(user.id);
+
+    if (banInfo) {
+      throw new ForbiddenException(
+        `계정이 정지되었습니다. 사유: ${banInfo.reason}`,
       );
     }
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -15,6 +15,7 @@ import { EmailService } from './Email/auth-email.service';
 import { AuthNativeController } from './auth-naitve/auth-native.controller';
 import { AuthNativeService } from './auth-naitve/auth-native.service';
 import { AuthNativeRepository } from './auth-naitve/auth-native.repository';
+import { ReportModule } from 'src/report/report.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { AuthNativeRepository } from './auth-naitve/auth-native.repository';
     UsersModule,
     HttpModule,
     FirebaseAdminModule,
+    ReportModule,
   ],
   providers: [
     AuthService,

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { UsersModule } from '../users/users.module';
@@ -26,7 +26,7 @@ import { ReportModule } from 'src/report/report.module';
     UsersModule,
     HttpModule,
     FirebaseAdminModule,
-    ReportModule,
+    forwardRef(() => ReportModule),
   ],
   providers: [
     AuthService,

--- a/src/common/dtos/res-message.dto.ts
+++ b/src/common/dtos/res-message.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResMessageDto {
+  @ApiProperty({
+    description: '처리 결과 메시지',
+    example: '요청이 성공적으로 처리되었습니다.',
+  })
+  message: string;
+}

--- a/src/common/enums/report-reason.enum.ts
+++ b/src/common/enums/report-reason.enum.ts
@@ -1,0 +1,12 @@
+import { ValueOf } from '../utils/type-utils';
+
+export const reportReasonValue = {
+  IMPERSONATION_FRAUD: 'IMPERSONATION_FRAUD', // 유출/사칭/사기
+  SEXUAL_CONTENT: 'SEXUAL_CONTENT', // 음란물/불건전한 대화
+  SPAM_AND_PHISHING: 'SPAM_AND_PHISHING', // 낚시/놀람/도배
+  ABUSIVE_LANGUAGE: 'ABUSIVE_LANGUAGE', // 욕설/비하
+  COMMERCIAL_AD: 'COMMERCIAL_AD', // 상업적 광고 및 판매
+  POLITICAL_PROPAGANDA: 'POLITICAL_PROPAGANDA', // 정당/정치인 비하 및 선거운동
+} as const;
+
+export type ReportReason = ValueOf<typeof reportReasonValue>;

--- a/src/letter/letter.module.ts
+++ b/src/letter/letter.module.ts
@@ -7,9 +7,16 @@ import { S3Module } from 'src/s3/s3.module';
 import { ImagePresignModule } from 'src/image/image-presign.module';
 import { AuthModule } from 'src/auth/auth.module';
 import { SantaUserIdProvider } from './santa-user-id.provider';
+import { ReportModule } from 'src/report/report.module';
 
 @Module({
-  imports: [UsersModule, S3Module, ImagePresignModule, AuthModule],
+  imports: [
+    UsersModule,
+    S3Module,
+    ImagePresignModule,
+    AuthModule,
+    ReportModule,
+  ],
   controllers: [LetterController],
   providers: [LetterService, LetterRepository, SantaUserIdProvider],
   exports: [LetterService],

--- a/src/letter/letter.repository.ts
+++ b/src/letter/letter.repository.ts
@@ -28,7 +28,7 @@ const letterSelect = {
   },
 };
 
-// (2) Prisma가 이 select의 타입을 추론하도록 유틸리티 타입 생성
+// Prisma가 이 select의 타입을 추론하도록 유틸리티 타입 생성
 // (이 타입을 Promise의 반환 타입으로 사용합니다)
 type LetterDetail = Prisma.LetterGetPayload<{
   select: typeof letterSelect;
@@ -37,6 +37,17 @@ type LetterDetail = Prisma.LetterGetPayload<{
 @Injectable()
 export class LetterRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  // [Helper] 차단된 유저 필터링 조건 생성 함수
+  // 내가 차단했거나(blockerId=나), 나를 차단한(blockedId=나) 사람 제외
+  private getBlockFilter(userId: number) {
+    return {
+      sender: {
+        blocksReceived: { none: { blockerId: userId } }, // 내가 차단한 사람이 아님
+        blocksSent: { none: { blockedId: userId } }, // 나를 차단한 사람이 아님
+      },
+    };
+  }
 
   /** 편지 전송 */
   sendLetter(
@@ -102,7 +113,10 @@ export class LetterRepository {
     return this.prisma.letter.findMany({
       where: {
         receiverId: userId,
-        status: { in: [LetterStatusValue.SENT, LetterStatusValue.RECEIVED] },
+        status: {
+          in: [LetterStatusValue.SENT, LetterStatusValue.RECEIVED],
+          ...this.getBlockFilter(userId),
+        },
       },
       // 'SENT'(안 읽음)가 'RECEIVED'(읽음)보다 먼저 오도록
       // 그 다음 최근 편지부터 정렬
@@ -203,8 +217,11 @@ export class LetterRepository {
       where: {
         id: letterId,
         OR: [
-          { senderId: userId }, // 내가 보냈거나
-          { receiverId: userId }, // 내가 받음
+          { senderId: userId }, // 내가 보낸거면 다 보이고
+          {
+            receiverId: userId, // 내가 받은거면
+            ...this.getBlockFilter(userId), // 차단필터 적용
+          },
         ],
       },
       select: letterSelect, // 공통 select 적용

--- a/src/letter/letter.repository.ts
+++ b/src/letter/letter.repository.ts
@@ -115,8 +115,8 @@ export class LetterRepository {
         receiverId: userId,
         status: {
           in: [LetterStatusValue.SENT, LetterStatusValue.RECEIVED],
-          ...this.getBlockFilter(userId),
         },
+        ...this.getBlockFilter(userId),
       },
       // 'SENT'(안 읽음)가 'RECEIVED'(읽음)보다 먼저 오도록
       // 그 다음 최근 편지부터 정렬

--- a/src/letter/letter.service.ts
+++ b/src/letter/letter.service.ts
@@ -72,18 +72,19 @@ export class LetterService {
 
   /** 단일 조회 */
   async findLetter(letterId: number, userId: number): Promise<ResLetterDto> {
-    const nowKst = nowKST();
+    // 신고기능 구현을 위해 임시 주석 처리 (12.03)
+    // const nowKst = nowKST();
 
-    const currentMonth = nowKst.getUTCMonth() + 1; // 0부터 시작하므로 +1
-    const currentDay = nowKst.getUTCDate();
+    // const currentMonth = nowKst.getUTCMonth() + 1; // 0부터 시작하므로 +1
+    // const currentDay = nowKst.getUTCDate();
 
-    // 2. 12월 25일 이전인지 체크
-    // (12월이 아니거나, 12월이어도 25일 전이라면)
-    if (currentMonth !== 12 || currentDay < 25) {
-      throw new ForbiddenException(
-        '아직 개봉할 수 없습니다! 12월 25일에 열어볼 수 있어요',
-      );
-    }
+    // // 2. 12월 25일 이전인지 체크
+    // // (12월이 아니거나, 12월이어도 25일 전이라면)
+    // if (currentMonth !== 12 || currentDay < 25) {
+    //   throw new ForbiddenException(
+    //     '아직 개봉할 수 없습니다! 12월 25일에 열어볼 수 있어요',
+    //   );
+    // }
 
     // 일단 편지 데이터를 조회
     const letter = await this.letterRepository.findLetterByIdAndUser(

--- a/src/letter/letter.service.ts
+++ b/src/letter/letter.service.ts
@@ -18,12 +18,14 @@ import { ResDraftLetterItemDto } from './dtos/res-draft-letter-item.dto';
 import { ResLetterDto } from './dtos/res-letter.dto';
 import { SANTA_USER_ID } from './santa-user-id.provider';
 import { nowKST } from 'src/common/functions/time.helper';
+import { ReportRepository } from 'src/report/report.repository';
 
 @Injectable()
 export class LetterService {
   constructor(
     private readonly letterRepository: LetterRepository,
     private readonly s3Service: S3Service,
+    private readonly reportRepository: ReportRepository,
     @Inject(SANTA_USER_ID) private readonly santaUserId: number,
   ) {
     console.log(`LetterService initialized with Santa ID: ${this.santaUserId}`);
@@ -34,9 +36,22 @@ export class LetterService {
     senderId: number,
     sendLetterDto: SendLetterDto,
   ): Promise<ResSendLetterDto> {
-    // 산타에게 편지 보내기 차단
+    // 1. 산타에게 편지 보내기 차단
     if (sendLetterDto.receiverId === this.santaUserId) {
       throw new BadRequestException('산타클로스에게 편지를 보낼 수 없습니다.');
+    }
+
+    // 2. 차단 관계 확인 (보내는 사람 <-> 받는 사람)
+    // ReportsRepository에 이 메서드를 추가해야 합니다 (아래 설명 참조)
+    const isBlocked = await this.reportRepository.checkBlockStatus(
+      senderId,
+      sendLetterDto.receiverId,
+    );
+
+    if (isBlocked) {
+      throw new ForbiddenException(
+        '차단 관계에 있는 사용자에게는 편지를 보낼 수 없습니다.',
+      );
     }
 
     return this.letterRepository.sendLetter({

--- a/src/report/dtos/ban-user.dto.ts
+++ b/src/report/dtos/ban-user.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class BanUserDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  adminComment: string; // 관리자가 남길 코멘트
+}

--- a/src/report/dtos/ban-user.dto.ts
+++ b/src/report/dtos/ban-user.dto.ts
@@ -1,10 +1,19 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
 export class BanUserDto {
-  @IsString()
+  @ApiProperty({
+    description: '밴 처리할 유저 ID',
+    example: 6,
+  })
+  @IsNumber()
   @IsNotEmpty()
   userId: number;
 
+  @ApiProperty({
+    description: '관리자 밴 사유 코멘트',
+    example: '지속적인 상업성 광고 게시로 인한 영구 정지',
+  })
   @IsString()
   @IsNotEmpty()
   adminComment: string; // 관리자가 남길 코멘트

--- a/src/report/dtos/create-report.dto.ts
+++ b/src/report/dtos/create-report.dto.ts
@@ -1,0 +1,19 @@
+import { IsNotEmpty, IsEnum, IsNumber } from 'class-validator';
+import {
+  ReportReason,
+  reportReasonValue,
+} from '../../common/enums/report-reason.enum';
+
+export class CreateReportDto {
+  @IsNumber()
+  @IsNotEmpty()
+  targetUserId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  letterId: number;
+
+  @IsEnum(reportReasonValue, { message: '유효하지 않은 신고 유형입니다.' })
+  @IsNotEmpty()
+  reason: ReportReason; // 클라이언트는 위 Enum String 중 하나를 보냄
+}

--- a/src/report/dtos/create-report.dto.ts
+++ b/src/report/dtos/create-report.dto.ts
@@ -1,18 +1,33 @@
-import { IsNotEmpty, IsEnum, IsNumber } from 'class-validator';
+import { IsNotEmpty, IsEnum, IsNumber, IsOptional } from 'class-validator';
 import {
   ReportReason,
   reportReasonValue,
 } from '../../common/enums/report-reason.enum';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateReportDto {
+  @ApiProperty({
+    description: '신고할 대상 유저의 ID',
+    example: 6,
+  })
   @IsNumber()
   @IsNotEmpty()
   targetUserId: number;
 
+  @ApiProperty({
+    description: '신고할 편지의 ID (편지 신고가 아닐 경우 생략 가능)',
+    example: 105,
+    required: false, // Swagger에서 Optional 표시
+  })
   @IsNumber()
-  @IsNotEmpty()
-  letterId: number;
+  @IsOptional()
+  letterId?: number;
 
+  @ApiProperty({
+    description: '신고 사유',
+    enum: reportReasonValue,
+    example: reportReasonValue.COMMERCIAL_AD, // Enum 값 예시
+  })
   @IsEnum(reportReasonValue, { message: '유효하지 않은 신고 유형입니다.' })
   @IsNotEmpty()
   reason: ReportReason; // 클라이언트는 위 Enum String 중 하나를 보냄

--- a/src/report/dtos/res-report-detail.dto.ts
+++ b/src/report/dtos/res-report-detail.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ResReportDto, ResReportReporterDto } from './res-report.dto';
+
+// 1. 신고 당한 유저 상세 정보 (닉네임 포함)
+class ResReportTargetDetailDto extends ResReportReporterDto {}
+
+// 2. 편지 상세 정보
+class ResReportLetterDetailDto {
+  @ApiProperty({ description: '편지 ID', example: 100 })
+  id: number;
+
+  @ApiProperty({
+    description: '편지 내용',
+    example: '이 유저가 광고를 보냈습니다...',
+  })
+  content: string;
+
+  @ApiProperty({
+    description: '이미지 URL',
+    example: 'https://s3...',
+    nullable: true,
+  })
+  imageUrl: string | null;
+
+  @ApiProperty({ description: '보낸 날짜', example: '2025-12-25T00:00:00Z' })
+  sentAt: Date;
+}
+
+// 3. [상세 조회용] 메인 DTO
+// 목록용 DTO(ResReportDto)를 상속받되, 덮어쓸 필드만 재정의합니다.
+export class ResReportDetailDto extends ResReportDto {
+  // [덮어쓰기] 상세 조회에서는 신고 당한 사람 닉네임도 보여줌
+  @ApiProperty({
+    description: '신고 당한 사람 상세 정보',
+    type: ResReportTargetDetailDto,
+  })
+  reportedUser: ResReportTargetDetailDto;
+
+  // [추가] 편지 상세 정보 (Nullable)
+  @ApiProperty({
+    description: '신고된 편지 상세 정보 (삭제되었거나 유저 신고인 경우 null)',
+    type: ResReportLetterDetailDto,
+    nullable: true,
+  })
+  letter: ResReportLetterDetailDto | null;
+}

--- a/src/report/dtos/res-report.dto.ts
+++ b/src/report/dtos/res-report.dto.ts
@@ -1,0 +1,55 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  ReportReason,
+  reportReasonValue,
+} from 'src/common/enums/report-reason.enum';
+
+// 1. 신고자 정보 (닉네임 포함)
+export class ResReportReporterDto {
+  @ApiProperty({ description: '유저 ID', example: 2 })
+  id: number;
+
+  @ApiProperty({ description: '닉네임', example: 'gw구글' })
+  nickname: string;
+}
+
+// 2. 신고 당한 유저 정보 (목록에서는 ID만)
+export class ResReportTargetSimpleDto {
+  @ApiProperty({ description: '유저 ID', example: 6 })
+  id: number;
+
+  @ApiProperty({ description: '닉네임', example: 'gw네이버' })
+  nickname: string;
+}
+
+// 3. [목록 조회용] 메인 DTO
+export class ResReportDto {
+  @ApiProperty({ description: '신고 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({
+    description: '신고 접수일',
+    example: '2025-11-26T06:18:45.037Z',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    description: '신고 사유',
+    enum: reportReasonValue,
+    enumName: 'ReportReason',
+    example: reportReasonValue.COMMERCIAL_AD,
+  })
+  reason: ReportReason;
+
+  @ApiProperty({ description: '처리 여부', example: false })
+  isResolved: boolean;
+
+  @ApiProperty({ description: '신고한 사람 정보', type: ResReportReporterDto })
+  reporter: ResReportReporterDto;
+
+  @ApiProperty({
+    description: '신고 당한 사람 정보',
+    type: ResReportTargetSimpleDto,
+  })
+  reportedUser: ResReportTargetSimpleDto;
+}

--- a/src/report/report.controller.ts
+++ b/src/report/report.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Post, Body, Get, UseGuards, Req } from '@nestjs/common';
+import { ReportService } from './report.service';
+import { AuthGuard } from '@nestjs/passport';
+import { GetUserId } from 'src/auth/decorators/get-user-id.decorator';
+import { CreateReportDto } from './dtos/create-report.dto';
+import { BanUserDto } from './dtos/ban-user.dto';
+
+@Controller('reports')
+export class ReportController {
+  constructor(private readonly reportService: ReportService) {}
+
+  // 1. [User] 사용자 신고 API
+  @Post()
+  @UseGuards(AuthGuard('accessToken'))
+  async createReport(
+    @GetUserId() userId: number,
+    @Body() dto: CreateReportDto,
+  ) {
+    await this.reportService.reportUser(userId, dto);
+    return {
+      message: '신고가 접수되었으며, 해당 사용자와 상호 차단되었습니다.',
+    };
+  }
+
+  // 2. [Admin] 신고 목록 조회 API
+  @Get('admin/list')
+  @UseGuards(AuthGuard('jwtAdmin')) // 관리자만 접근 가능하도록 설정
+  async getReports() {
+    return this.reportService.getPendingReports();
+  }
+
+  // 3. [Admin] 유저 밴 API
+  @Post('admin/ban')
+  @UseGuards(AuthGuard('jwtAdmin'))
+  async banUser(@Body() dto: BanUserDto) {
+    await this.reportService.banUser(dto);
+    return { message: '사용자가 성공적으로 밴 처리되었습니다.' };
+  }
+}

--- a/src/report/report.controller.ts
+++ b/src/report/report.controller.ts
@@ -1,17 +1,30 @@
-import { Controller, Post, Body, Get, UseGuards, Req } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  Get,
+  UseGuards,
+  Req,
+  Param,
+  ParseIntPipe,
+} from '@nestjs/common';
 import { ReportService } from './report.service';
 import { AuthGuard } from '@nestjs/passport';
 import { GetUserId } from 'src/auth/decorators/get-user-id.decorator';
 import { CreateReportDto } from './dtos/create-report.dto';
 import { BanUserDto } from './dtos/ban-user.dto';
+import { ApiTags } from '@nestjs/swagger';
+import { ApiReports } from './report.swagger';
 
 @Controller('reports')
+@ApiTags('reports')
 export class ReportController {
   constructor(private readonly reportService: ReportService) {}
 
-  // 1. [User] 사용자 신고 API
+  // [User] 사용자 신고 API
   @Post()
   @UseGuards(AuthGuard('accessToken'))
+  @ApiReports.create()
   async createReport(
     @GetUserId() userId: number,
     @Body() dto: CreateReportDto,
@@ -22,18 +35,37 @@ export class ReportController {
     };
   }
 
-  // 2. [Admin] 신고 목록 조회 API
-  @Get('admin/list')
+  // [Admin] 신고 목록 조회 API
+  @Get('list')
   @UseGuards(AuthGuard('jwtAdmin')) // 관리자만 접근 가능하도록 설정
+  @ApiReports.findAllPending()
   async getReports() {
     return this.reportService.getPendingReports();
   }
 
-  // 3. [Admin] 유저 밴 API
-  @Post('admin/ban')
+  // [Admin] 상세 조회 API (편지 내용 확인용)
+  @Get(':reportId')
   @UseGuards(AuthGuard('jwtAdmin'))
+  @ApiReports.findOne()
+  async getReportDetail(@Param('reportId', ParseIntPipe) reportId: number) {
+    return this.reportService.getReportDetail(reportId);
+  }
+
+  // [Admin] 유저 밴 API
+  @Post('ban')
+  @UseGuards(AuthGuard('jwtAdmin'))
+  @ApiReports.banUser()
   async banUser(@Body() dto: BanUserDto) {
     await this.reportService.banUser(dto);
     return { message: '사용자가 성공적으로 밴 처리되었습니다.' };
+  }
+
+  // [Admin] 신고 반려 (무혐의) API
+  @Post('/:reportId/dismiss')
+  @UseGuards(AuthGuard('jwtAdmin'))
+  @ApiReports.dismiss()
+  async dismissReport(@Param('reportId', ParseIntPipe) reportId: number) {
+    await this.reportService.dismissReport(reportId);
+    return { message: '신고가 반려 처리되었습니다. (밴 없음, 차단 유지)' };
   }
 }

--- a/src/report/report.module.ts
+++ b/src/report/report.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { ReportController } from './report.controller';
 import { ReportService } from './report.service';
 import { ReportRepository } from './report.repository';
+import { S3Module } from 'src/s3/s3.module';
 
 @Module({
+  imports: [S3Module],
   providers: [ReportService, ReportRepository],
   controllers: [ReportController],
   exports: [ReportRepository],

--- a/src/report/report.module.ts
+++ b/src/report/report.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ReportController } from './report.controller';
+import { ReportService } from './report.service';
+import { ReportRepository } from './report.repository';
+
+@Module({
+  providers: [ReportService, ReportRepository],
+  controllers: [ReportController],
+  exports: [ReportRepository],
+})
+export class ReportModule {}

--- a/src/report/report.repository.ts
+++ b/src/report/report.repository.ts
@@ -1,0 +1,105 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { Report, Ban, ReportReason } from '@prisma/client';
+import { CreateReportDto } from './dtos/create-report.dto';
+import { BanUserDto } from './dtos/ban-user.dto';
+
+@Injectable()
+export class ReportRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findBanByUserId(userId: number): Promise<Ban | null> {
+    return this.prisma.ban.findUnique({
+      where: { userId: userId },
+    });
+  }
+
+  /**
+   * [User]신고 생성 및 상호 차단 처리 (Transaction)
+   */
+  async createReportWithMutualBlock(
+    reporterId: number,
+    dto: CreateReportDto,
+  ): Promise<Report> {
+    return this.prisma.$transaction(async (tx) => {
+      // 1. 신고 내역 생성
+      const report = await tx.report.create({
+        data: {
+          reporterId: reporterId,
+          reportedUserId: dto.targetUserId,
+          letterId: dto.letterId,
+          reason: dto.reason, // Enum 값 저장
+        },
+      });
+
+      // 2. 상호 차단 생성 (서로의 글을 안 보이게 함)
+      // createMany + skipDuplicates: true 조합으로 이미 차단된 경우 에러 없이 무시
+      await tx.block.createMany({
+        data: [
+          { blockerId: reporterId, blockedId: dto.targetUserId },
+          { blockerId: dto.targetUserId, blockedId: reporterId },
+        ],
+        skipDuplicates: true,
+      });
+
+      return report;
+    });
+  }
+
+  /**
+   * [Admin] 처리되지 않은 신고 목록 조회
+   */
+  async findAllPendingReports() {
+    return this.prisma.report.findMany({
+      where: { isResolved: false },
+      include: {
+        reporter: { select: { id: true, nickname: true } },
+        reportedUser: { select: { id: true } },
+        letter: true, // 문제의 편지 내용 확인
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  /**
+   * [Admin] 유저 밴 처리 및 신고 상태 업데이트 (Transaction)
+   */
+  async banUser(dto: BanUserDto): Promise<Ban> {
+    return this.prisma.$transaction(async (tx) => {
+      // 1. 밴 테이블에 기록
+      const ban = await tx.ban.create({
+        data: {
+          userId: dto.userId,
+          reason: dto.adminComment,
+        },
+      });
+
+      // 2. 해당 유저에 대한 미처리 신고들을 모두 '처리됨'으로 변경
+      await tx.report.updateMany({
+        where: {
+          reportedUserId: dto.userId,
+          isResolved: false,
+        },
+        data: { isResolved: true },
+      });
+
+      return ban;
+    });
+  }
+
+  /**
+   * 두 사용자 간에 차단 관계가 존재하는지 확인 (양방향 체크)
+   * true 반환 시: 서로 편지 전송/조회 불가
+   */
+  async checkBlockStatus(userId1: number, userId2: number): Promise<boolean> {
+    const count = await this.prisma.block.count({
+      where: {
+        OR: [
+          { blockerId: userId1, blockedId: userId2 }, // 1이 2를 차단
+          { blockerId: userId2, blockedId: userId1 }, // 2가 1을 차단
+        ],
+      },
+    });
+    return count > 0;
+  }
+}

--- a/src/report/report.repository.ts
+++ b/src/report/report.repository.ts
@@ -52,12 +52,63 @@ export class ReportRepository {
   async findAllPendingReports() {
     return this.prisma.report.findMany({
       where: { isResolved: false },
-      include: {
-        reporter: { select: { id: true, nickname: true } },
-        reportedUser: { select: { id: true } },
-        letter: true, // 문제의 편지 내용 확인
+      select: {
+        id: true,
+        reason: true,
+        isResolved: true,
+        createdAt: true,
+        reporter: {
+          select: {
+            id: true,
+            nickname: true,
+          },
+        },
+        reportedUser: {
+          select: {
+            id: true,
+            nickname: true,
+          },
+        },
       },
       orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  /**
+   * [Admin] 신고 단건 상세 조회 (편지 내용 포함)
+   */
+  async findReportDetail(reportId: number) {
+    return this.prisma.report.findUnique({
+      where: { id: reportId },
+      // select를 사용하면 최상단의 reporterId, reportedUserId 등이 제외됩니다.
+      select: {
+        id: true,
+        reason: true,
+        createdAt: true,
+        // isResolved: true, // 필요하다면 주석 해제 (요청하신 JSON에는 없어서 뺌)
+
+        reporter: {
+          select: {
+            id: true,
+            nickname: true,
+            // email: true, // 필요 시 추가
+          },
+        },
+        reportedUser: {
+          select: {
+            id: true,
+            nickname: true,
+          },
+        },
+        letter: {
+          select: {
+            id: true,
+            content: true,
+            imageUrl: true, // S3 URL 생성을 위해 필수
+            sentAt: true,
+          },
+        },
+      },
     });
   }
 
@@ -84,6 +135,23 @@ export class ReportRepository {
       });
 
       return ban;
+    });
+  }
+
+  /**
+   * 신고 ID로 조회
+   */
+  async findReportById(reportId: number) {
+    return this.prisma.report.findUnique({ where: { id: reportId } });
+  }
+
+  /**
+   * 신고 처리 상태 업데이트
+   */
+  async updateReportStatus(reportId: number, isResolved: boolean) {
+    return this.prisma.report.update({
+      where: { id: reportId },
+      data: { isResolved },
     });
   }
 

--- a/src/report/report.service.ts
+++ b/src/report/report.service.ts
@@ -1,0 +1,37 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { CreateReportDto } from './dtos/create-report.dto';
+import { BanUserDto } from './dtos/ban-user.dto';
+import { ReportRepository } from './report.repository';
+
+@Injectable()
+export class ReportService {
+  constructor(private readonly reportRepository: ReportRepository) {}
+
+  // [User] 신고하기
+  async reportUser(userId: number, dto: CreateReportDto) {
+    // 추가 로직: 본인이 본인을 신고하는지 체크 등
+    if (userId === dto.targetUserId) {
+      throw new BadRequestException('본인은 신고할 수 없습니다.');
+    }
+
+    return this.reportRepository.createReportWithMutualBlock(userId, dto);
+  }
+
+  // [Admin] 신고 목록 보기
+  async getPendingReports() {
+    return this.reportRepository.findAllPendingReports();
+  }
+
+  // [Admin] 유저 밴 하기
+  async banUser(dto: BanUserDto) {
+    const existingBan = await this.reportRepository.findBanByUserId(dto.userId);
+
+    if (existingBan) {
+      // 이미 밴 기록이 있다면 400 Bad Request 에러 발생
+      throw new BadRequestException(
+        `해당 사용자(ID: ${dto.userId})는 이미 밴 처리되었습니다. (사유: ${existingBan.reason})`,
+      );
+    }
+    return this.reportRepository.banUser(dto);
+  }
+}

--- a/src/report/report.service.ts
+++ b/src/report/report.service.ts
@@ -1,11 +1,19 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateReportDto } from './dtos/create-report.dto';
 import { BanUserDto } from './dtos/ban-user.dto';
 import { ReportRepository } from './report.repository';
+import { S3Service } from 'src/s3/s3.service';
 
 @Injectable()
 export class ReportService {
-  constructor(private readonly reportRepository: ReportRepository) {}
+  constructor(
+    private readonly reportRepository: ReportRepository,
+    private readonly s3Service: S3Service,
+  ) {}
 
   // [User] 신고하기
   async reportUser(userId: number, dto: CreateReportDto) {
@@ -22,6 +30,37 @@ export class ReportService {
     return this.reportRepository.findAllPendingReports();
   }
 
+  // [Admin] 신고 상세 조회
+  async getReportDetail(reportId: number) {
+    const report = await this.reportRepository.findReportDetail(reportId);
+    if (!report) {
+      throw new NotFoundException('해당 신고 내역을 찾을 수 없습니다.');
+    }
+
+    let presignedUrl: string | null = null;
+
+    if (report.letter && report.letter.imageUrl) {
+      presignedUrl = await this.s3Service.generateGetObjectPresignedUrl(
+        report.letter.imageUrl,
+      );
+    }
+    // 응답 데이터 구조 재구성
+    // (Prisma 결과의 letter 객체에 presignedUrl을 넣어주고 imageUrl은 숨김)
+    const { letter, ...reportData } = report;
+
+    return {
+      ...reportData,
+      letter: letter
+        ? {
+            id: letter.id,
+            content: letter.content,
+            sentAt: letter.sentAt,
+            presignedUrl: presignedUrl, // [핵심] 생성된 URL 주입
+          }
+        : null, // 편지가 삭제되었거나 없는 경우 null
+    };
+  }
+
   // [Admin] 유저 밴 하기
   async banUser(dto: BanUserDto) {
     const existingBan = await this.reportRepository.findBanByUserId(dto.userId);
@@ -33,5 +72,23 @@ export class ReportService {
       );
     }
     return this.reportRepository.banUser(dto);
+  }
+
+  /**
+   * [Admin] 신고 반려 (밴 하지 않고 처리 완료로 변경)
+   */
+  async dismissReport(reportId: number) {
+    // 해당 신고가 존재하는지 확인
+    const report = await this.reportRepository.findReportById(reportId);
+    if (!report) {
+      throw new NotFoundException('존재하지 않는 신고 내역입니다.');
+    }
+
+    if (report.isResolved) {
+      throw new BadRequestException('이미 처리된 신고 내역입니다.');
+    }
+
+    // Repository를 통해 상태만 업데이트 (isResolved -> true)
+    return this.reportRepository.updateReportStatus(reportId, true);
   }
 }

--- a/src/report/report.swagger.ts
+++ b/src/report/report.swagger.ts
@@ -1,0 +1,166 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
+import { CreateReportDto } from './dtos/create-report.dto';
+import { BanUserDto } from './dtos/ban-user.dto';
+// [참고] 목록 조회 시 반환될 DTO가 필요합니다. 없다면 만들어두시는 게 좋습니다.
+import { ResReportDto } from './dtos/res-report.dto';
+import { ResMessageDto } from 'src/common/dtos/res-message.dto';
+import { ResReportDetailDto } from './dtos/res-report-detail.dto';
+
+// 1. 공통 401 Unauthorized
+const ApiUnauthorizedResponse = ApiResponse({
+  status: 401,
+  description: '인증 실패 (유효하지 않은 토큰 또는 토큰 없음)',
+  content: {
+    'application/json': {
+      example: {
+        statusCode: 401,
+        message: 'Unauthorized',
+      },
+    },
+  },
+});
+
+// 2. 관리자 전용 403 Forbidden (필요 시 사용)
+const ApiForbiddenResponse = ApiResponse({
+  status: 403,
+  description: '접근 권한 없음 (관리자 계정이 아님)',
+  content: {
+    'application/json': {
+      example: {
+        statusCode: 403,
+        message: 'Forbidden resource',
+      },
+    },
+  },
+});
+
+export const ApiReports = {
+  /** POST /reports (사용자 신고) */
+  create: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '사용자 신고',
+        description:
+          '특정 사용자를 신고합니다. 신고 즉시 신고자와 대상자는 **상호 차단** 처리되어 서로의 편지를 볼 수 없게 됩니다.',
+      }),
+      ApiBody({
+        description: '신고 대상 및 사유',
+        type: CreateReportDto,
+      }),
+      ApiBearerAuth('accessToken'),
+      ApiResponse({
+        status: 201,
+        description: '신고 접수 및 차단 완료',
+        type: ResMessageDto,
+      }),
+      ApiResponse({
+        status: 400,
+        description: '잘못된 요청 (본인 신고 등)',
+      }),
+      ApiResponse({
+        status: 409,
+        description: '이미 신고/차단된 사용자',
+      }),
+      ApiUnauthorizedResponse,
+    ),
+
+  /** GET /reports/admin/list (관리자 - 신고 목록 조회) */
+  findAllPending: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '미처리 신고 목록 조회 (관리자)',
+        description: '편지 내용 없이 가벼운 요약 목록을 반환합니다.',
+      }),
+      ApiBearerAuth('jwtAdmin'),
+      ApiResponse({
+        status: 200,
+        description: '신고 목록 조회 성공',
+        type: ResReportDto, // ✅ 목록용 DTO 적용
+        isArray: true,
+      }),
+      ApiUnauthorizedResponse,
+      ApiForbiddenResponse,
+    ),
+
+  /** GET /reports/admin/:reportId (관리자 - 상세 조회) */
+  findOne: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '신고 상세 조회 (관리자)',
+        description: '신고의 상세 내용과 관련된 편지 원본을 조회합니다.',
+      }),
+      ApiBearerAuth('jwtAdmin'),
+      ApiParam({
+        name: 'reportId',
+        description: '조회할 신고 ID',
+        type: Number,
+        example: 1,
+      }),
+      ApiResponse({
+        status: 200,
+        description: '신고 상세 정보 조회 성공',
+        type: ResReportDetailDto, // ✅ 상세용 DTO 적용
+      }),
+      ApiResponse({
+        status: 404,
+        description: '존재하지 않는 신고 ID',
+      }),
+      // ... 에러 응답
+    ),
+
+  /** POST /reports/admin/ban (관리자 - 유저 밴) */
+  banUser: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '유저 밴 처리 (관리자)',
+        description:
+          '신고된 유저를 영구 정지(Ban) 시키고, 관련된 모든 신고 내역을 처리됨(Resolved) 상태로 변경합니다.',
+      }),
+      ApiBody({
+        description: '밴 대상 유저 ID 및 관리자 코멘트',
+        type: BanUserDto,
+      }),
+      ApiBearerAuth('jwtAdmin'),
+      ApiResponse({
+        status: 201,
+        description: '밴 처리 성공',
+        type: ResMessageDto,
+      }),
+      ApiResponse({
+        status: 400,
+        description: '이미 밴 처리된 유저이거나 잘못된 요청',
+      }),
+      ApiUnauthorizedResponse,
+      ApiForbiddenResponse,
+    ),
+  dismiss: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '신고 반려 (관리자)',
+        description:
+          '신고 내용을 검토했으나 밴 사유가 아니라고 판단될 때 사용합니다. 해당 신고를 "처리됨" 상태로 변경하여 목록에서 제거합니다. (기존 차단 관계는 유지됩니다)',
+      }),
+      ApiParam({
+        name: 'reportId',
+        description: '처리할 신고 내역의 ID',
+        type: Number,
+      }),
+      ApiBearerAuth('jwtAdmin'),
+      ApiResponse({
+        status: 201, // Post 요청이므로 201 또는 200
+        description: '반려 처리 성공',
+        type: ResMessageDto,
+      }),
+      ApiResponse({
+        status: 404,
+        description: '존재하지 않는 신고 ID',
+      }),
+    ),
+};

--- a/src/s3/s3.module.ts
+++ b/src/s3/s3.module.ts
@@ -1,10 +1,10 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { S3Service } from './s3.service';
 import { S3Controller } from './s3.controller';
 import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
-  imports: [AuthModule],
+  imports: [forwardRef(() => AuthModule)],
   controllers: [S3Controller],
   providers: [S3Service],
   exports: [S3Service],

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -76,6 +76,16 @@ export class UsersRepository {
         NOT: {
           id: myId, // 2. 본인 ID 제외
         },
+        AND: [
+          {
+            // 내가 차단한 사람이 아닐 것 (수신한 차단 목록에 내가 없어야 함)
+            blocksReceived: { none: { blockerId: myId } },
+          },
+          {
+            // 나를 차단한 사람이 아닐 것 (발신한 차단 목록에 내가 없어야 함)
+            blocksSent: { none: { blockedId: myId } },
+          },
+        ],
       },
       select: {
         id: true,


### PR DESCRIPTION
## #️⃣연관된 이슈

- #83 

## 📝작업 내용
<img width="551" height="337" alt="image" src="https://github.com/user-attachments/assets/a618bf69-46dc-4cf0-9d4a-e3562e7f4007" />

추가된 API는 5개 입니다.
post /reports 로 신고 접수를 할 수 있고
신고 API 를 제외하고 관리자 토큰을 포함해야 합니다.
+ 신고시 편지 id를 nullable로 설정해놨기 때문에 신고 상세조회시 편지 정보도 nullable이고
편지에 포함된 이미지가 있다면 이미지를 가져옵니다.

- 노션에서 /백엔드/API 에 reports 도메인에서 사용되는 ENUM 값 적어놨습니다. 작업할때 참고해주세요.

---

### 신고기능을 고려해서 수정한 기능들은
- 편지 조회 및 보내기를 차단 했습니다.
- 편지 보내기 전 zipCode로 유저 검색이 안되도록 했습니다.
- 관리자가 ban 처리를 했다면 로그인이 안되게 했습니다.
- 보내거나 임시 상태의 편지는 차단 여부와 상관없이 모두 조회되고 받은 편지만 차단여부에 따라 필터링 합니다.
- 편지 삭제시 신고 기록은 남아 있습니다.
- 유저가 탈퇴시 신고 기록도 전부 삭제 됩니다.
---
신고 조회 화면은 관리자 페이지에서  하면 될 것 같고,
단일 편지 조회 한 화면 상단에 신고버튼이 있으면 되겠다는 생각인데 좋은 디자인이 있다면 그거에 맞춰 작업해주세요 ~


## 💬전달 사항


